### PR TITLE
Check yml files list in target folder

### DIFF
--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -20,5 +20,12 @@ Options:
 
 when isMainModule:
   let args = docopt(doc)
-  if args["c"] == true and not args["<CSV-FILE>"]:
+  if args["<CSV-FILE>"]:
     let csvData = getHayabusaCsvData($args["<CSV-FILE>"])
+    if args["<hayabusa-rulespath>"]:
+      let rulePath: string = args["<hayabusa-rulespath>"]
+      for f in walkDirRec(rulePath, "*.yml"):
+
+    if args["c"] == true and args["<column>"]:
+      let targetColumn = args["<column>"]
+      csvData[targetColumn]

--- a/src/takajopkg/submodule.nim
+++ b/src/takajopkg/submodule.nim
@@ -5,7 +5,16 @@
 
 import std/tables
 import std/parsecsv
+import std/os
+import std/strutils
 from std/streams import newFileStream
+
+proc getYMLLists*(targetDirPath: string): seq[string] =
+  var r: seq[string] = @[]
+  for f in walkDirRec(targetDirPath):
+    if f.endsWith(".yml"):
+      r.insert(f)
+  return r
 
 proc getHayabusaCsvData*(csvPath: string): Tableref[string, seq[string]] =
   ## procedure for Hayabusa output csv read data.

--- a/tests/testsubmodule.nim
+++ b/tests/testsubmodule.nim
@@ -34,3 +34,6 @@ test "csv file path import":
   writeFile("temp.csv", expect_content)
   check getHayabusaCsvData("./tests/data/1.csv") == expect_table
 
+test "check getYMLLists":
+  let expect = @["tests\\data\\1.yml"]
+  check getYMLLists("./tests") == expect


### PR DESCRIPTION
## What Changed
- added proc getYMLLists 
- added test

## Evidence
```
 >nimble test
  Verifying dependencies for takajo@0.1.0
      Info: Dependency on docopt@>= 0.6 already satisfied
  Verifying dependencies for docopt@0.6.8
      Info: Dependency on regex@>= 0.7.4 already satisfied
  Verifying dependencies for regex@0.19.0
      Info: Dependency on unicodedb@>= 0.7.2 already satisfied
  Verifying dependencies for unicodedb@0.10.0
  Compiling C:\Users\nexts\opensource\hayabusa-tools\tests\testsubmodule (from package takajo) using c backend
[OK] csv file path import
[OK] check getYMLLists
   Success: Execution finished
   Success: All tests passed
```