### PR TITLE
Added display logo

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -8,3 +8,4 @@
 
 - `list-undetected-evtx-files`: 検知しなかったルールファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
 - `list-unused-rules`: 検知しなかったevtxファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
+- ロゴを追加。`-q --quiet`で表示しないようにできる。 (#12) (@hitenkoku)

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -8,4 +8,4 @@
 
 - `list-undetected-evtx-files`: 検知しなかったルールファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
 - `list-unused-rules`: 検知しなかったevtxファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
-- ロゴを追加。`-q --quiet`で表示しないようにできる。 (#12) (@hitenkoku)
+- ロゴを追加。`-q, --quiet`で表示しないようにできる。 (#12) (@hitenkoku)

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -8,4 +8,4 @@
 
 - `list-undetected-evtx-files`: 検知しなかったルールファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
 - `list-unused-rules`: 検知しなかったevtxファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
-- ロゴを追加。`-q, --quiet`で表示しないようにできる。 (#12) (@hitenkoku)
+- ロゴを追加。`-q, --quiet`で表示しないようにできる。 (#12) (@YamatoSecurity @hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
-- Added Logo. If you want to hide the logo, use the `-q, --quiet` option. (#12) (@hitenkoku)
+- Added Logo. If you want to hide the logo, use the `-q, --quiet` option. (#12) (@YamatoSecurity @hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
-- Added Logo. If you want to hidden logo, would use `-q --quiet` option. (#12) (@hitenkoku)
+- Added Logo. If you want to hide the logo, use the `-q, --quiet` option. (#12) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
+- Added Logo. If ou want to hidden logo, would use `-q --quiet` option. (#12) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
-- Added Logo. If ou want to hidden logo, would use `-q --quiet` option. (#12) (@hitenkoku)
+- Added Logo. If you want to hidden logo, would use `-q --quiet` option. (#12) (@hitenkoku)

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -7,8 +7,11 @@ import std/tables
 import takajopkg/submodule
 
 proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
-    columnName: system.string = "EvtxFile"): int =
+    columnName: system.string = "EvtxFile", quiet: bool = false): int =
   ## List up undetected evtx files.
+
+  if not quiet:
+    outputLogo()
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(evtxDir, ".evtx")
@@ -39,8 +42,11 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
 
 
 proc listUnusedRules(timeline: string, rulesDir: string,
-    columnName = "RuleFile"): int =
+    columnName = "RuleFile", quiet: bool = false): int =
   ## List up unused rules.
+
+  if not quiet:
+    outputLogo()
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(rulesDir, ".yml")
@@ -66,7 +72,6 @@ proc listUnusedRules(timeline: string, rulesDir: string,
     echo ""
   discard
 
-
 when isMainModule:
   clCfg.version = "0.0.1"
 
@@ -76,7 +81,8 @@ when isMainModule:
       help = {
       "timeline": "CSV timeline created by Hayabusa with verbose profile.",
       "evtxDir": "The directory of .evtx files you scanned with Hayabusa.",
-      "columnName": "Column header name."
+      "columnName": "Column header name.",
+      "quiet": "Quiet mode: do not display the launch banner",
       }
     ],
     [

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -8,10 +8,9 @@ import takajopkg/submodule
 
 proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
     columnName: system.string = "EvtxFile", quiet: bool = false): int =
-  ## List up undetected evtx files.
 
   if not quiet:
-    outputLogo()
+    echo outputLogo()
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(evtxDir, ".evtx")
@@ -43,10 +42,9 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
 
 proc listUnusedRules(timeline: string, rulesDir: string,
     columnName = "RuleFile", quiet: bool = false): int =
-  ## List up unused rules.
 
   if not quiet:
-    outputLogo()
+    echo outputLogo()
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(rulesDir, ".yml")
@@ -74,10 +72,12 @@ proc listUnusedRules(timeline: string, rulesDir: string,
 
 when isMainModule:
   clCfg.version = "0.0.1"
+  clCfg.useMulti = outputLogo() & "Usage:\n  $command {SUBCMD}  [sub-command options & parameters]\nwhere {SUBCMD} is one of:\n$subcmds\n$command {-h|--help} or with no args at all prints this message.\n$command --help-syntax gives general cligen syntax help.\nRun \"$command {help SUBCMD|SUBCMD --help}\" to see help for just SUBCMD.\nRun \"$command help\" to get *comprehensive* help.${ifVersion}\n"
 
   dispatchMulti(
     [
       listUndetectedEvtxFiles, cmdName = "list-undetected-evtx-files",
+      doc = "List up undetected evtx files.",
       help = {
       "timeline": "CSV timeline created by Hayabusa with verbose profile.",
       "evtxDir": "The directory of .evtx files you scanned with Hayabusa.",
@@ -87,6 +87,7 @@ when isMainModule:
     ],
     [
       listUnusedRules, cmdName = "list-unused-rules",
+      doc = "List up unused rules.",
       help = {
         "rulesDir": "Hayabusa rules directory."
       }

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -1,16 +1,17 @@
 import cligen
+import os
+import terminal
 import std/sequtils
 import std/strformat
 import std/strutils
 import std/tables
-
 import takajopkg/submodule
 
 proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
     columnName: system.string = "EvtxFile", quiet: bool = false): int =
 
   if not quiet:
-    echo outputLogo()
+    styledEcho(fgGreen,outputLogo())
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(evtxDir, ".evtx")
@@ -44,7 +45,7 @@ proc listUnusedRules(timeline: string, rulesDir: string,
     columnName = "RuleFile", quiet: bool = false): int =
 
   if not quiet:
-    echo outputLogo()
+    styledEcho(fgGreen,outputLogo())
 
   let csvData: TableRef[string, seq[string]] = getHayabusaCsvData(timeline, columnName)
   var fileLists: seq[string] = getTargetExtFileLists(rulesDir, ".yml")
@@ -72,24 +73,29 @@ proc listUnusedRules(timeline: string, rulesDir: string,
 
 when isMainModule:
   clCfg.version = "0.0.1"
-  clCfg.useMulti = outputLogo() & "Usage:\n  $command {SUBCMD}  [sub-command options & parameters]\nwhere {SUBCMD} is one of:\n$subcmds\n$command {-h|--help} or with no args at all prints this message.\n$command --help-syntax gives general cligen syntax help.\nRun \"$command {help SUBCMD|SUBCMD --help}\" to see help for just SUBCMD.\nRun \"$command help\" to get *comprehensive* help.${ifVersion}\n"
 
+  if paramCount() == 0:
+    styledEcho(fgGreen,outputLogo())
   dispatchMulti(
     [
       listUndetectedEvtxFiles, cmdName = "list-undetected-evtx-files",
-      doc = "List up undetected evtx files.",
+      doc = "List up undetected evtx files",
       help = {
-      "timeline": "CSV timeline created by Hayabusa with verbose profile.",
-      "evtxDir": "The directory of .evtx files you scanned with Hayabusa.",
-      "columnName": "Column header name.",
-      "quiet": "Quiet mode: do not display the launch banner",
+        "timeline": "CSV timeline created by Hayabusa with verbose profile",
+        "evtxDir": "The directory of .evtx files you scanned with Hayabusa",
+        "columnName": "Optional: column header name",
+        "quiet": "Quiet mode: do not display the launch banner"
       }
     ],
     [
       listUnusedRules, cmdName = "list-unused-rules",
-      doc = "List up unused rules.",
+      doc = "List up unused rules",
       help = {
-        "rulesDir": "Hayabusa rules directory."
+        "timeline": "CSV timeline created by Hayabusa with verbose profile",
+        "rulesDir": "Hayabusa rules directory",
+        "columnName": "Optional: column header name",
+        "quiet": "Quiet mode: do not display the launch banner"
       }
     ]
   )
+

--- a/src/takajopkg/submodule.nim
+++ b/src/takajopkg/submodule.nim
@@ -1,8 +1,3 @@
-# This is just an example to get you started. Users of your hybrid library will
-# import this file by writing ``import takajopkg/submodule``. Feel free to rename or
-# remove this file altogether. You may create additional modules alongside
-# this file as required.
-
 import std/os
 import std/parsecsv
 import std/sequtils
@@ -12,16 +7,14 @@ import std/tables
 from std/streams import newFileStream
 
 proc outputLogo*(): string =
-  ## output logo
   let logo = """
-╔════════╦╗╔═╦═══╗ ╔╦═══╗
+╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
 ║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
 ╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
-  ║║ ║╚═╝║╔╗║║╚═╝╠╗║║║ ║║
+  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
  ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
  ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
    by Yamato Security
-
 """
   return logo
 

--- a/src/takajopkg/submodule.nim
+++ b/src/takajopkg/submodule.nim
@@ -11,7 +11,7 @@ import std/strutils
 import std/tables
 from std/streams import newFileStream
 
-proc outputLogo*() =
+proc outputLogo*(): string =
   ## output logo
   let logo = """
 ╔════════╦╗╔═╦═══╗ ╔╦═══╗
@@ -22,8 +22,8 @@ proc outputLogo*() =
  ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
    by Yamato Security
 
-  """
-  echo logo
+"""
+  return logo
 
 proc getUnlistedSeq*(targetSeq: seq[string], compareSeq: seq[string]): seq[string] =
   ## get element not in compareSeq

--- a/src/takajopkg/submodule.nim
+++ b/src/takajopkg/submodule.nim
@@ -11,6 +11,20 @@ import std/strutils
 import std/tables
 from std/streams import newFileStream
 
+proc outputLogo*() =
+  ## output logo
+  let logo = """
+╔════════╦╗╔═╦═══╗ ╔╦═══╗
+║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
+╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
+  ║║ ║╚═╝║╔╗║║╚═╝╠╗║║║ ║║
+ ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
+ ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
+   by Yamato Security
+
+  """
+  echo logo
+
 proc getUnlistedSeq*(targetSeq: seq[string], compareSeq: seq[string]): seq[string] =
   ## get element not in compareSeq
   var output: seq[string] = @[]


### PR DESCRIPTION
# What Changed

- Added Display logo

## Evidence

``` bash
>./takajo.exe
╔════════╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗║║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
   by Yamato Security

Usage:
  takajo {SUBCMD}  [sub-command options & parameters]
where {SUBCMD} is one of:
  help                        print comprehensive or per-cmd help
  list-undetected-evtx-files  List up undetected evtx files.
  list-unused-rules           List up unused rules.

takajo {-h|--help} or with no args at all prints this message.
takajo --help-syntax gives general cligen syntax help.
Run "takajo {help SUBCMD|SUBCMD --help}" to see help for just SUBCMD.
Run "takajo help" to get *comprehensive* help.
Top-level --version also available

```

- --quiet option 
```
> ./takajo.exe list-undetected-evtx-files -t .\takajo2.csv -e ..\hayabusa-sample-evtx\DeepBlueCLI\ -q
Finished.
---------------
Undetected evtx files:

many-events-application.evtx

4.762% of the evtx files did not have any detections.
Number of evtx files not detected: 1
```
