### PR TITLE
added output feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dmypy.json
 #Takajo binaries
 takajo
 takajo*.exe
+
+#Results files
+*.txt

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -9,3 +9,4 @@
 - `list-undetected-evtx-files`: 検知しなかったルールファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
 - `list-unused-rules`: 検知しなかったevtxファイルの一覧を表示する機能を追加した。 (#4) (@hitenkoku)
 - ロゴを追加。`-q, --quiet`で表示しないようにできる。 (#12) (@YamatoSecurity @hitenkoku)
+- `-o, --output`オプションの追加。結果を別ファイルにtxt形式で出力する機能を追加した。 (#11) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
 - Added Logo. If you want to hide the logo, use the `-q, --quiet` option. (#12) (@YamatoSecurity @hitenkoku)
+- Added result output option. (`-q, --quiet` ) (#11) (@hitenkoku)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@
 - `list-undetected-evtx-files`: List up all of the `.evtx` files that Hayabusa didn't have a detection rule for. (#4) (@hitenkoku)
 - `list-unused-rules`: List up all of the `.yml` detection rules that were not used. (#4) (@hitenkoku)
 - Added Logo. If you want to hide the logo, use the `-q, --quiet` option. (#12) (@YamatoSecurity @hitenkoku)
-- Added result output option. (`-q, --quiet` ) (#11) (@hitenkoku)
+- Added result output option. (`-o, --output` ) (#11) (@hitenkoku)

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -72,14 +72,18 @@ Nimがインストールされている場合、以下のコマンドでソー�
 Hayabusa実行時に`%EvtxFile%`の情報が含まれたプロファイルを使ってcsvを出力して下さい。プロファイルごとにHayabusaのcsvに出力される情報は異なります。詳細は[こちら](https://github.com/Yamato-Security/hayabusa#profiles)を確認して下さい。
 
 必須オプション:
-  - -t, --timeline ../hayabusa/timeline.csv: Hayabusaで作成されたCSVタイムライン。
-  - -e --evtx-dir ../hayabusa-sample-evtx: Hayabusaでスキャンした`.evtx`ファイルが存在するディレクトリ。
+
+- `-t, --timeline ../hayabusa/timeline.csv`: Hayabusaで作成されたCSVタイムライン。
+- `-e --evtx-dir ../hayabusa-sample-evtx`: Hayabusaでスキャンした`.evtx`ファイルが存在するディレクトリ。
 
 任意オプション:
-  - `-c, --column-name EvtxColumn`: カスタムなカラム名を指定する。デフォルトではHayabusaのデフォルトの`EvtxFile`が使用される。
-  - `-q, --quiet`: ロゴを表示しない。
+
+- `-c, --column-name EvtxColumn`: カスタムなカラム名を指定する。デフォルトではHayabusaのデフォルトの`EvtxFile`が使用される。
+- `-o, --output result.txt`: 結果をテキストファイルに保存する。デフォルトは画面出力になる。
+- `-q, --quiet`: ロゴを表示しない。
 
 例:
+
 ```bash
 takajo.exe undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx
 ```
@@ -88,14 +92,18 @@ takajo.exe undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evt
 Hayabusa実行時に`%RuleFile%`の情報が含まれたプロファイルを使ってcsvを出力して下さい。プロファイルごとにHayabusaのcsvに出力される情報は異なります。プロファイルごとにHayabusaのcsvに出力される情報は異なります。詳細は[こちら](https://github.com/Yamato-Security/hayabusa#profiles)を確認して下さい。
 
 必須オプション:
-  - -t, --timeline timeline.csv: Hayabusaで作成されたCSVタイムライン。
-  - -r --rules-dir ../hayabusa/rules: Hayabusaでスキャンした`.yml`ファイルが存在するディレクトリ。
+
+- -t, --timeline timeline.csv: Hayabusaで作成されたCSVタイムライン。
+- -r --rules-dir ../hayabusa/rules: Hayabusaでスキャンした`.yml`ファイルが存在するディレクトリ。
 
 任意オプション:
-  - `-c, --column-name CustomRuleFileColumn`: カスタムなカラム名を指定する。デフォルトではHayabusaのデフォルトの`RuleFile`が使用される。
-  - `-q, --quiet`: ロゴを表示しない。
+
+- `-c, --column-name CustomRuleFileColumn`: カスタムなカラム名を指定する。デフォルトではHayabusaのデフォルトの`RuleFile`が使用される。
+- `-o, --output result.txt`: 結果をテキストファイルに保存する。デフォルトは画面出力になる。
+- `-q, --quiet`: ロゴを表示しない。
 
 例:
+
 ```bash
 takajo.exe unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules
 ```

--- a/README.md
+++ b/README.md
@@ -71,14 +71,18 @@ You first need to run Hayabusa with a profile that saves the `%EvtxFile%` column
 You can see which columns Hayabusa saves according to the different profiles [here](https://github.com/Yamato-Security/hayabusa#profiles).
 
 Required options:
-  - `-t, --timeline ../hayabusa/timeline.csv`: CSV timeline created by Hayabusa.
-  - `-e, --evtx-dir ../hayabusa-sample-evtx`: The directory of `.evtx` files you scanned with Hayabusa.
+
+- `-t, --timeline ../hayabusa/timeline.csv`: CSV timeline created by Hayabusa.
+- `-e, --evtx-dir ../hayabusa-sample-evtx`: The directory of `.evtx` files you scanned with Hayabusa.
 
 Options:
-  - `-c, --column-name CustomEvtxColumn`: Optional: Specify a custom column name for the evtx column. Default is Hayabusa's default of `EvtxFile`.
-  - `-q, --quiet`: Do not display logo.
+
+- `-c, --column-name CustomEvtxColumn`: Optional: Specify a custom column name for the evtx column. Default is Hayabusa's default of `EvtxFile`.
+- `-o, --output`: Save the results to a text file. The default is to print to screen.
+- `-q, --quiet`: Do not display logo.
 
 Example:
+
 ```bash
 takajo.exe undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx
 ```
@@ -93,10 +97,13 @@ Required options:
 - `-r, --rules-dir ../hayabusa/rules`: The directory of `.yml` rules files you used with Hayabusa.
 
 Options:
-  - `-c, --column-name CustomRuleFileColumn`: Specify a custom column name for the rule file column. Default is Hayabusa's default of `RuleFile`.
-  - `-q, --quiet`: Do not display logo.
+
+- `-c, --column-name CustomRuleFileColumn`: Specify a custom column name for the rule file column. Default is Hayabusa's default of `RuleFile`.
+- `-o, --output`: Save the results to a text file. The default is to print to screen.
+- `-q, --quiet`: Do not display logo.
 
 Example:
+
 ```bash
 takajo.exe unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules
 ```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Required options:
 Options:
 
 - `-c, --column-name CustomEvtxColumn`: Optional: Specify a custom column name for the evtx column. Default is Hayabusa's default of `EvtxFile`.
-- `-o, --output`: Save the results to a text file. The default is to print to screen.
+- `-o, --output result.txt`: Save the results to a text file. The default is to print to screen.
 - `-q, --quiet`: Do not display logo.
 
 Example:
@@ -99,7 +99,7 @@ Required options:
 Options:
 
 - `-c, --column-name CustomRuleFileColumn`: Specify a custom column name for the rule file column. Default is Hayabusa's default of `RuleFile`.
-- `-o, --output`: Save the results to a text file. The default is to print to screen.
+- `-o, --output result.txt`: Save the results to a text file. The default is to print to screen.
 - `-q, --quiet`: Do not display logo.
 
 Example:

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -23,14 +23,14 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
   let checkResult = getUnlistedSeq(fileLists, detectedPaths)
   var outputStock: seq[string] = @[]
 
-  outputStock.add("Finished. ")
-  outputStock.add("---------------")
+  echo "Finished. "
+  echo "---------------"
 
   if checkResult.len == 0:
     echo "Great! No undetected evtx files were found."
     echo ""
   else:
-    echo "Undetected evtx file `identified."
+    echo "Undetected evtx file identified."
     echo ""
     var numberOfEvtxFiles = 0
     for undetectedFile in checkResult:
@@ -38,15 +38,16 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
       inc numberOfEvtxFiles
     outputStock.add("")
     let undetectedPercentage = (checkResult.len() / fileLists.len()) * 100
-    outputStock.add(fmt"{ undetectedPercentage :.4}% of the evtx files did not have any detections.")
-    outputStock.add(fmt"Number of evtx files not detected: {numberOfEvtxFiles}")
-    outputStock.add("")
+    echo fmt"{ undetectedPercentage :.4}% of the evtx files did not have any detections."
+    echo fmt"Number of evtx files not detected: {numberOfEvtxFiles}"
+    echo ""
   if output != "":
     let f = open(output, fmWrite)
     defer: f.close()
     for line in outputStock:
       f.writeLine(line)
     echo fmt"Saved File {output}"
+    echo ""
   else:
     echo outputstock.join("\n")
   discard
@@ -81,15 +82,16 @@ proc listUnusedRules(timeline: string, rulesDir: string,
       inc numberOfUnusedRules
     let undetectedPercentage = (checkResult.len() / fileLists.len()) * 100
     outputStock.add("")
-    outputStock.add(fmt"{ undetectedPercentage :.4}% of the yml rules were not used.")
-    outputStock.add(fmt"Number of unused rule files: {numberOfUnusedRules}")
-    outputStock.add("")
+    echo fmt"{ undetectedPercentage :.4}% of the yml rules were not used."
+    echo fmt"Number of unused rule files: {numberOfUnusedRules}"
+    echo ""
   if output != "":
     let f = open(output, fmWrite)
     defer: f.close()
     for line in outputStock:
       f.writeLine(line)
     echo fmt"Saved File {output}"
+    echo ""
   else:
     echo outputstock.join("\n")
   discard

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -97,7 +97,7 @@ proc listUnusedRules(timeline: string, rulesDir: string,
   discard
 
 when isMainModule:
-  clCfg.version = "0.0.1"
+  clCfg.version = "1.0.0-dev"
   const examples = "Examples:\n  undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx\n  unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules\n"
   clCfg.useMulti = "Usage: takajo.exe <COMMAND>\n\nCommands:\n$subcmds\nCommand help: $command help <COMMAND>\n\n" & examples
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -28,8 +28,9 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
 
   if checkResult.len == 0:
     echo "Great! No undetected evtx files were found."
+    echo ""
   else:
-    echo "Undetected evtx files:"
+    echo "Undetected evtx file `identified."
     echo ""
     var numberOfEvtxFiles = 0
     for undetectedFile in checkResult:
@@ -45,6 +46,7 @@ proc listUndetectedEvtxFiles(timeline: string, evtxDir: string,
     defer: f.close()
     for line in outputStock:
       f.writeLine(line)
+    echo fmt"Saved File {output}"
   else:
     echo outputstock.join("\n")
   discard
@@ -61,6 +63,7 @@ proc listUnusedRules(timeline: string, rulesDir: string,
   var fileLists: seq[string] = getTargetExtFileLists(rulesDir, ".yml")
   var detectedPaths: seq[string] = csvData[columnName].map(getFileNameWithExt)
   detectedPaths = deduplicate(detectedPaths)
+  var outputStock: seq[string] = @[]
 
   echo "Finished. "
   echo "---------------"
@@ -68,17 +71,27 @@ proc listUnusedRules(timeline: string, rulesDir: string,
   let checkResult = getUnlistedSeq(fileLists, detectedPaths)
   if checkResult.len == 0:
     echo "Great! No unused rule files were found."
+    echo ""
   else:
-    echo "Unused rule files:"
+    echo "Unused rule file identified."
+    echo ""
     var numberOfUnusedRules = 0
     for undetectedFile in checkResult:
-      echo undetectedFile
+      outputStock.add(undetectedFile)
       inc numberOfUnusedRules
     let undetectedPercentage = (checkResult.len() / fileLists.len()) * 100
-    echo ""
-    echo fmt"{ undetectedPercentage :.4}% of the yml rules were not used."
-    echo "Number of unused rule files: ", numberOfUnusedRules
-    echo ""
+    outputStock.add("")
+    outputStock.add(fmt"{ undetectedPercentage :.4}% of the yml rules were not used.")
+    outputStock.add(fmt"Number of unused rule files: {numberOfUnusedRules}")
+    outputStock.add("")
+  if output != "":
+    let f = open(output, fmWrite)
+    defer: f.close()
+    for line in outputStock:
+      f.writeLine(line)
+    echo fmt"Saved File {output}"
+  else:
+    echo outputstock.join("\n")
   discard
 
 when isMainModule:

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -65,16 +65,16 @@ proc listUnusedRules(timeline: string, rulesDir: string,
   echo "Finished. "
   echo "---------------"
 
-  let output = getUnlistedSeq(fileLists, detectedPaths)
-  if output.len == 0:
+  let checkResult = getUnlistedSeq(fileLists, detectedPaths)
+  if checkResult.len == 0:
     echo "Great! No unused rule files were found."
   else:
     echo "Unused rule files:"
     var numberOfUnusedRules = 0
-    for undetectedFile in output:
+    for undetectedFile in checkResult:
       echo undetectedFile
       inc numberOfUnusedRules
-    let undetectedPercentage = (output.len() / fileLists.len()) * 100
+    let undetectedPercentage = (checkResult.len() / fileLists.len()) * 100
     echo ""
     echo fmt"{ undetectedPercentage :.4}% of the yml rules were not used."
     echo "Number of unused rule files: ", numberOfUnusedRules

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -73,11 +73,11 @@ proc listUnusedRules(timeline: string, rulesDir: string,
 
 when isMainModule:
   clCfg.version = "0.0.1"
-  const examples = "Examples:\n  undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx\n  unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules\n" 
+  const examples = "Examples:\n  undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx\n  unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules\n"
   clCfg.useMulti = "Usage: takajo.exe <COMMAND>\n\nCommands:\n$subcmds\nCommand help: $command help <COMMAND>\n\n" & examples
 
   if paramCount() == 0:
-    styledEcho(fgGreen,outputLogo())
+    styledEcho(fgGreen, outputLogo())
   dispatchMulti(
     [
       listUndetectedEvtxFiles, cmdName = "undetected-evtx",
@@ -86,7 +86,8 @@ when isMainModule:
         "timeline": "CSV timeline created by Hayabusa with verbose profile",
         "evtxDir": "The directory of .evtx files you scanned with Hayabusa",
         "columnName": "Specify custom column header name",
-        "quiet": "Do not display the launch banner"
+        "quiet": "Do not display the launch banner",
+        "output": "Save the results to a text file. The default is to print to screen.",
       }
     ],
     [
@@ -96,7 +97,8 @@ when isMainModule:
         "timeline": "CSV timeline created by Hayabusa with verbose profile",
         "rulesDir": "Hayabusa rules directory",
         "columnName": "Specify custom column header name",
-        "quiet": "Do not display the launch banner"
+        "quiet": "Do not display the launch banner",
+        "output": "Save the results to a text file. The default is to print to screen.",
       }
     ]
   )

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "1.0.0-dev"
 author        = "Yamato Security @SecurityYamato"
 description   = "Takajo is Hayabusa output analyzer."
 license       = "GPL-3.0"

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.0.0-dev"
+version       = "1.0.0"
 author        = "Yamato Security @SecurityYamato"
 description   = "Takajo is Hayabusa output analyzer."
 license       = "GPL-3.0"


### PR DESCRIPTION
## What Changed

- added output option (`-o, --output`)
  - feature of output result to text file 
- readme update
- changelog update
- changed version num (0.0.1 -> 1.0.0-dev)

## Evidence

- [evtx.txt](https://github.com/Yamato-Security/takajo/files/9741344/evtx.txt)

<details>
<summary>
./takajo.exe undetected-evtx -t .\takajo2.csv -e ..\hayabusa-sample-evtx\ -o evtx.txt
</summary>

```
> ./takajo.exe undetected-evtx -t .\takajo2.csv -e ..\hayabusa-sample-evtx\ -o evtx.txt
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
   by Yamato Security

Finished. 
---------------
Undetected evtx file identified.

17.41% of the evtx files did not have any detections.
Number of evtx files not detected: 101

Saved File evtx.txt
```

</details>

- [rules.txt](https://github.com/Yamato-Security/takajo/files/9741348/rules.txt)

<details>
<summary>./takajo.exe unused-rules -t .\takajo2.csv -r ..\hayabusa\rules\ -o rules.txt</summary>

```
> ./takajo.exe unused-rules -t .\takajo2.csv -r ..\hayabusa\rules\ -o rules.txt
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
   by Yamato Security

Finished. 
---------------
Unused rule file identified.

75.59% of the yml rules were not used.
Number of unused rule files: 1514

Saved File rules.txt
```

</details>