### PR TITLE
feat: add `split-json-timeline` command

### DIFF
--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -96,7 +96,7 @@ when isMainModule:
             help = {
                 "outputDir": "output directory (default: output)",
                 "quiet": "do not display the launch banner",
-                "timeline": "CSV timeline created by Hayabusa",
+                "timeline": "JSONL timeline created by Hayabusa",
             }
         ],
         [

--- a/src/takajopkg/splitJsonTimeline.nim
+++ b/src/takajopkg/splitJsonTimeline.nim
@@ -40,12 +40,12 @@ proc splitJsonTimeline( outputDir: string = "output", quiet: bool = false, timel
             filenameSequence.add(filename)
             var outputFile = open(filename, fmWrite)
             filesTable[computerName] = outputFile
-            outputFile.write(jsonLine)
+            outputFile.write(line)
             outputFile.write("\p")
             flushFile(outputFile)
         else:
             var outputFile = filesTable[computerName]
-            outputFile.write(jsonLine)
+            outputFile.write(line)
             outputFile.write("\p")
             flushFile(outputFile)
     bar.finish()

--- a/src/takajopkg/splitJsonTimeline.nim
+++ b/src/takajopkg/splitJsonTimeline.nim
@@ -2,7 +2,13 @@ proc splitJsonTimeline( outputDir: string = "output", quiet: bool = false, timel
     let startTime = epochTime()
     if not quiet:
         styledEcho(fgGreen, outputLogo())
+    if not os.fileExists(timeline):
+        echo "The file '" & timeline & "' does not exist. Please specify a valid file path."
+        quit(1)
 
+    echo "Calculating total lines in the JSONL file. Please wait."
+    let totalLines = countLinesInTimeline(timeline)
+    echo "Total lines: ", totalLines
     echo ""
     echo "Splitting the Hayabusa JSONL timeline into separate timelines according to the computer name."
 
@@ -10,8 +16,48 @@ proc splitJsonTimeline( outputDir: string = "output", quiet: bool = false, timel
         echo ""
         echo "The directory '" & outputDir & "' does not exist so will be created."
         createDir(outputDir)
+    echo ""
 
-    echo "Not implemented yet."
+    var
+        inputFile = open(timeline, FileMode.fmRead)
+        filenameSequence: seq[string] = @[]
+        filesTable = initTable[string, File]()
+        bar = newProgressBar(total = totalLines)
+        lineCount = 0
+        updateInterval = max(totalLines div 500, 1)
+    bar.start()
+
+    for line in lines(timeline):
+        inc(lineCount)
+        if lineCount mod updateInterval == 0:  # Update about every .2% of lines
+            bar.set(lineCount)
+        updateInterval = max(totalLines div 500, 1)  # Update about every .2% of lines, but at least once per line
+        let jsonLine = parseJson(line)
+        let computerName = jsonLine["Computer"].getStr()
+
+        if not filesTable.hasKey(computerName):
+            let filename = outputDir & "/" & computerName & "-HayabusaResults.jsonl"
+            filenameSequence.add(filename)
+            var outputFile = open(filename, fmWrite)
+            filesTable[computerName] = outputFile
+            outputFile.write(jsonLine)
+            outputFile.write("\p")
+            flushFile(outputFile)
+        else:
+            var outputFile = filesTable[computerName]
+            outputFile.write(jsonLine)
+            outputFile.write("\p")
+            flushFile(outputFile)
+    bar.finish()
+
+    # Close all opened files
+    for file in filesTable.values:
+        close(file)
+
+    echo ""
+    for fn in filenameSequence:
+        let fileSize = getFileSize(fn)
+        echo "Created the file: " & fn & " (" & formatFileSize(fileSize) & ")"
 
     echo ""
 


### PR DESCRIPTION
## What Changed
Added split-json-timeline command.

## Evidence
### Environment 
- OS: macOS montery version 13.4
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8
- Nim Compiler Version 1.6.12[macOS: arm64] 

### Test1
`help/version` option works.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % ./takajo split-json-timeline -h
Usage:
  split-json-timeline [REQUIRED,optional-params]
split up a large JSONL timeline into smaller ones based on the computer name (input: JSONL, profile: any)
Options:
  -h, --help                           print this cligen-erated help
  --help-syntax                        advanced: prepend,plurals,..
  --version          bool    false     print version
  -o=, --outputDir=  string  "output"  output directory (default: output)
  -q, --quiet        bool    false     do not display the launch banner
  -t=, --timeline=   string  REQUIRED  CSV timeline created by Hayabusa
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % ./takajo split-json-timeline --version
2.0.0-dev
```

### Test2(hayabusa-sample-evtx)

I confirmed command can be executed successfully as follows.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % ./takajo split-json-timeline -t out.jsonl -o Case-01
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Calculating total lines in the JSONL file. Please wait.
Total lines: 32046

Splitting the Hayabusa JSONL timeline into separate timelines according to the computer name.

The directory 'Case-01' does not exist so will be created.

[==================================================================================================================================] 100.00%

Created the file: Case-01/37L4247D28-05-HayabusaResults.jsonl (41.83 KB)
Created the file: Case-01/IE8Win7-HayabusaResults.jsonl (104.76 KB)
Created the file: Case-01/IE9Win7-HayabusaResults.jsonl (12.36 KB)
Created the file: Case-01/IE10Win7-HayabusaResults.jsonl (6.31 MB)
Created the file: Case-01/DESKTOP-M5SN04R-HayabusaResults.jsonl (4.12 MB)
Created the file: Case-01/--HayabusaResults.jsonl (1.38 KB)
Created the file: Case-01/2016dc.hqcorp.local-HayabusaResults.jsonl (418 Bytes)
Created the file: Case-01/2012r2srv.maincorp.local-HayabusaResults.jsonl (2.15 KB)
Created the file: Case-01/SEC511-HayabusaResults.jsonl (2.98 MB)
Created the file: Case-01/IEWIN7-HayabusaResults.jsonl (1.28 MB)
Created the file: Case-01/WIN-77LTAPHIQ1R.example.corp-HayabusaResults.jsonl (74.54 KB)
Created the file: Case-01/PC01.example.corp-HayabusaResults.jsonl (921.26 KB)
Created the file: Case-01/ICORP-DC.internal.corp-HayabusaResults.jsonl (46.65 KB)
Created the file: Case-01/PC02.example.corp-HayabusaResults.jsonl (5.56 KB)
Created the file: Case-01/PC04.example.corp-HayabusaResults.jsonl (66.99 KB)
Created the file: Case-01/DC1.insecurebank.local-HayabusaResults.jsonl (202.54 KB)
Created the file: Case-01/DESKTOP-JR78RLP-HayabusaResults.jsonl (167.46 KB)
Created the file: Case-01/Sec504Student-HayabusaResults.jsonl (4.57 KB)
Created the file: Case-01/SANS-TBT570-HayabusaResults.jsonl (1.61 KB)
Created the file: Case-01/alice.insecurebank.local-HayabusaResults.jsonl (33.26 KB)
Created the file: Case-01/MSEDGEWIN10-HayabusaResults.jsonl (2.14 MB)
Created the file: Case-01/User-PC-HayabusaResults.jsonl (612 Bytes)
Created the file: Case-01/Isaac-HayabusaResults.jsonl (1.04 KB)
Created the file: Case-01/LAPTOP-JU4M3I0E-HayabusaResults.jsonl (137.66 KB)
Created the file: Case-01/win10.ecorp.com-HayabusaResults.jsonl (8.78 KB)
Created the file: Case-01/fs02.offsec.lan-HayabusaResults.jsonl (72.26 KB)
Created the file: Case-01/rootdc1.offsec.lan-HayabusaResults.jsonl (438.29 KB)
Created the file: Case-01/jump01.offsec.lan-HayabusaResults.jsonl (60.44 KB)
Created the file: Case-01/wec02-HayabusaResults.jsonl (1.43 KB)
Created the file: Case-01/01566s-win16-ir.threebeesco.com-HayabusaResults.jsonl (48.21 KB)
Created the file: Case-01/mssql01.offsec.lan-HayabusaResults.jsonl (835.20 KB)
Created the file: Case-01/DESKTOP-RIPCLIP-HayabusaResults.jsonl (6.50 KB)
Created the file: Case-01/04246w-win10.threebeesco.com-HayabusaResults.jsonl (3.01 KB)
Created the file: Case-01/DESKTOP-PIU87N6-HayabusaResults.jsonl (5.83 KB)
Created the file: Case-01/02694w-win10.threebeesco.com-HayabusaResults.jsonl (9.84 KB)
Created the file: Case-01/DESKTOP-NTSSLJD-HayabusaResults.jsonl (20.26 KB)
Created the file: Case-01/WIN10-client01.offsec.lan-HayabusaResults.jsonl (16.46 KB)
Created the file: Case-01/DESKTOP-ST69BPO-HayabusaResults.jsonl (923 Bytes)
Created the file: Case-01/FX-BS7-HayabusaResults.jsonl (10.69 KB)
Created the file: Case-01/srvdefender01.offsec.lan-HayabusaResults.jsonl (2.74 MB)
Created the file: Case-01/fs03vuln.offsec.lan-HayabusaResults.jsonl (1.59 MB)
Created the file: Case-01/win10-02.offsec.lan-HayabusaResults.jsonl (2.78 MB)
Created the file: Case-01/webiis01.offsec.lan-HayabusaResults.jsonl (4.15 KB)
Created the file: Case-01/pki01.offsec.lan-HayabusaResults.jsonl (4.13 KB)
Created the file: Case-01/atanids01.offsec.lan-HayabusaResults.jsonl (3.89 KB)
Created the file: Case-01/exchange01.offsec.lan-HayabusaResults.jsonl (17.32 KB)
Created the file: Case-01/adfs01.offsec.lan-HayabusaResults.jsonl (4.13 KB)
Created the file: Case-01/fs01.offsec.lan-HayabusaResults.jsonl (144.84 KB)
Created the file: Case-01/prtg-mon.offsec.lan-HayabusaResults.jsonl (4.15 KB)
Created the file: Case-01/atacore01.offsec.lan-HayabusaResults.jsonl (3.89 KB)
Created the file: Case-01/dhcp01.offsec.lan-HayabusaResults.jsonl (8.46 KB)
Created the file: Case-01/wsus01.offsec.lan-HayabusaResults.jsonl (4.13 KB)
Created the file: Case-01/DC-Server-1.labcorp.local-HayabusaResults.jsonl (11.40 KB)
Created the file: Case-01/sv-dc.hinokabegakure-no-sato.local-HayabusaResults.jsonl (959 Bytes)
Created the file: Case-01/FS03.offsec.lan-HayabusaResults.jsonl (7.11 MB)
Created the file: Case-01/PC-01.cybercat.local-HayabusaResults.jsonl (13.91 KB)
Created the file: Case-01/wef.windomain.local-HayabusaResults.jsonl (4.00 KB)
Created the file: Case-01/DESKTOP-TTEQ6PR-HayabusaResults.jsonl (2.71 KB)
Created the file: Case-01/dc1.test.local-HayabusaResults.jsonl (18.50 KB)
Created the file: Case-01/WIN-HayabusaResults.jsonl (25.92 KB)
Created the file: Case-01/wind10.winlab.local-HayabusaResults.jsonl (7.20 KB)
Created the file: Case-01/YamatoSecurity-HayabusaResults.jsonl (1011 Bytes)
Created the file: Case-01/DESKTOP-VQBONAV-HayabusaResults.jsonl (19.41 KB)
Created the file: Case-01/GUAPOS-PC-HayabusaResults.jsonl (1.89 KB)

Elapsed time: 0 hours, 0 minutes, 0 seconds
```

and There is no diff as follows.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % find ./Case-01 | xargs cat | sort > sorted-takajo.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % cat out.jsonl | sort > sorted-hayabusa.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % diff sorted-takajo.jsonl sorted-hayabusa.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms %
```

### Test3(all-evtx)

I confirmed command can be executed successfully as follows.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % ./takajo split-json-timeline -t big.jsonl -o Case-01
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Calculating total lines in the JSONL file. Please wait.
Total lines: 1627312

Splitting the Hayabusa JSONL timeline into separate timelines according to the computer name.

The directory 'Case-01' does not exist so will be created.

[================================================================================================================================] 100.00%

Created the file: Case-01/37L4247D28-05-HayabusaResults.jsonl (43.31 KB)
Created the file: Case-01/WIN-VR474TJ38H3-HayabusaResults.jsonl (11.72 KB)
Created the file: Case-01/DESKTOP-A8CALR3-HayabusaResults.jsonl (130.42 MB)
Created the file: Case-01/WIN-KPO4DDU11AB-HayabusaResults.jsonl (63.93 KB)
Created the file: Case-01/DESKTOP-6D0DBMB-HayabusaResults.jsonl (222.23 MB)
Created the file: Case-01/WIN-TKC15D7KHUR-HayabusaResults.jsonl (15.49 MB)
Created the file: Case-01/evtx-PC-HayabusaResults.jsonl (32.35 MB)
Created the file: Case-01/WIN-FPV0DSIC9O6-HayabusaResults.jsonl (19.07 MB)
Created the file: Case-01/WIN-FPV0DSIC9O6.sigma.fr-HayabusaResults.jsonl (40.71 MB)
Created the file: Case-01/WIN-06FB45IHQ35-HayabusaResults.jsonl (58.78 KB)
Created the file: Case-01/Agamemnon-HayabusaResults.jsonl (1.06 GB)

Elapsed time: 0 hours, 0 minutes, 22 seconds
```

and no diff as follows.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % find ./Case-01 | xargs cat | sort > sorted-takajo.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % cat big.jsonl| sort > sorted-hayabusa.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % diff sorted-takajo.jsonl sorted-hayabusa.jsonl
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms %
```

### Test4(Invalid file path)
If you specify a file path that does not exist, the following message will be output.
```
fukusuke@fukusukenoAir hayabusa-2.6.0-all-platforms % ./takajo split-json-timeline -t not-exsits.jsonl -o Case-01 -q
The file 'not-exsits.jsonl' does not exist. Please specify a valid file path.
```