### PR TITLE
fix: suru compile error with Nim 2.0.0

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,8 +1,29 @@
 # 変更点
 
-## v1.0.0 [2022/10/28]
+## x.x.x [xxxx/xx/xx]
 
-- [Code Blue 2022 Bluebox](https://codeblue.jp/2022/en/talks/?content=talks_24)での正式リリース。
+**改善:**
+
+- TakajoがNim 2.0.0でコンパイルできるようになった。(#31) (@fukusuket)
+
+## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
+
+**新機能:**
+
+- `list-domains`: `vt-domain-lookup`コマンドで使用する、重複のないドメインのリストを作成する。 (@YamatoSecurity)
+- `list-hashes`: `vt-hash-lookup`で使用するプロセスのハッシュ値のリストを作成する。 (@YamatoSecurity)
+- `list-ip-addresses`: `vt-ip-lookup`コマンドで使用する、重複のない送信元/送信先のIPリストを作成する。 (@YamatoSecurity)
+- `split-csv-timeline`: コンピューター名に基づき、大きなCSVタイムラインを小さなCSVタイムラインに分割する。 (@YamatoSecurity)
+- `split-json-timeline`: コンピューター名に基づき、大きなJSONLタイムラインを小さなJSONLタイムラインに分割する。 (@fukusuket)
+- `stack-logons`: ユーザー名、コンピューター名、送信元IPアドレス、送信元コンピューター名など、項目ごとの上位ログオンを出力する。 (@YamatoSecurity)
+- `sysmon-process-tree`: プロセスツリーを出力する。 (@hitenkoku)
+- `timeline-logon`: ログオンイベントのCSVタイムラインを作成する。 (@YamatoSecurity)
+- `timeline-suspicious-processes`: 不審なプロセスのCSVタイムラインを作成する。 (@YamatoSecurity)
+- `vt-domain-lookup`: VirusTotalでドメインのリストを検索し、悪意のあるドメインをレポートする。 (@YamatoSecurity)
+- `vt-hash-lookup`: VirusTotalでハッシュのリストを検索し、悪意のあるハッシュ値をレポートする。 (@YamatoSecurity)
+- `vt-ip-lookup`: VirusTotalでIPアドレスのリストを検索し、悪意のあるIPアドレスをレポートする。 (@YamatoSecurity)
+
+## v1.0.0 [2022/10/28] - [Code Blue 2022 Bluebox Release](https://codeblue.jp/2022/en/talks/?content=talks_24)
 
 **新機能:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Enhancements:**
 
-- Takajo now compiles with nim 2.0.0. (#31) (@fukusuket)
+- Takajo now compiles with Nim 2.0.0. (#31) (@fukusuket)
 
 - `list-domains`: create a
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,31 @@
 # Changes
 
-## v2.0.0 [2022/08/03]
+## x.x.x [xxxx/xx/xx]
 
-- Major update released at the [SANS DFIR Summit in Austin](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/).
+**Enhancements:**
+
+- Takajo now compiles with nim 2.0.0. (#31) (@fukusuket)
+
+- `list-domains`: create a
+
+## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 
 **New Features:**
 
-- `list-domains`: create a list of unique domains (input: JSONL, profile: standard) (@YamatoSecurity)
-- `list-hashes`: create a list of process hashes to be used with vt-hash-lookup (input: JSONL, profile: standard) (@YamatoSecurity)
-- `list-ip-addresses`: create a list of unique target and/or source IP addresses (input: JSONL, profile: standard) (@YamatoSecurity)
-- `split-csv-timeline`: split up a large CSV file into smaller ones based on the computer name (input: non-multiline CSV, profile: any) (@YamatoSecurity)
-- `split-json-timeline`: split up a large JSONL timeline into smaller ones based on the computer name (input: JSONL, profile: any) (@fukusuket)
-- `stack-logons`: stack logons by target user, target computer, source IP address and source computer (input: JSONL, profile: standard) (@YamatoSecurity)
-- `sysmon-process-tree`: output the process tree of a certain process (input: JSONL, profile: standard) (@hitenkoku)
-- `timeline-logon`: create a CSV timeline of logon events (input: JSONL, profile: standard) (@YamatoSecurity)
-- `timeline-suspicious-processes`: create a CSV timeline of suspicious processes (input: JSONL, profile: standard) (@YamatoSecurity)
-- `vt-domain-lookup`: look up a list of domains on VirusTotal (input: text file) (@YamatoSecurity)
-- `vt-hash-lookup`: look up a list of hashes on VirusTotal (input: text file) (@YamatoSecurity)
-- `vt-ip-lookup`: look up a list of IP addresses on VirusTotal (input: text file) (@YamatoSecurity)
+- `list-domains`: create a list of unique domains. (@YamatoSecurity)
+- `list-hashes`: create a list of process hashes to be used with vt-hash-lookup. (@YamatoSecurity)
+- `list-ip-addresses`: create a list of unique target and/or source IP addresses. (@YamatoSecurity)
+- `split-csv-timeline`: split up a large CSV file into smaller ones based on the computer name. (@YamatoSecurity)
+- `split-json-timeline`: split up a large JSONL timeline into smaller ones based on the computer name. (@fukusuket)
+- `stack-logons`: stack logons by target user, target computer, source IP address and source computer. (@YamatoSecurity)
+- `sysmon-process-tree`: output the process tree of a certain process. (@hitenkoku)
+- `timeline-logon`: create a CSV timeline of logon events. (@YamatoSecurity)
+- `timeline-suspicious-processes`: create a CSV timeline of suspicious processes. (@YamatoSecurity)
+- `vt-domain-lookup`: look up a list of domains on VirusTotal. (@YamatoSecurity)
+- `vt-hash-lookup`: look up a list of hashes on VirusTotal. (@YamatoSecurity)
+- `vt-ip-lookup`: look up a list of IP addresses on VirusTotal. (@YamatoSecurity)
 
-## v1.0.0 [2022/10/28]
-
-- Official release at [Code Blue 2022 Bluebox](https://codeblue.jp/2022/en/talks/?content=talks_24).
+## v1.0.0 [2022/10/28] - [Code Blue 2022 Bluebox Release](https://codeblue.jp/2022/en/talks/?content=talks_24)
 
 **New Features:**
 

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -14,4 +14,4 @@ bin           = @["takajo"]
 requires "nim >= 1.6.12"
 requires "cligen >= 1.5"
 #requires "terminaltables"
-requires "suru"
+requires "suru#f6f1e607c585b2bc2f71309996643f0555ff6349"


### PR DESCRIPTION
## What Changed

- Fixed #31
- Explicitly specify the installed version of `suru` as the latest commit [f6f1e607c585b2bc2f71309996643f0555ff6349](https://github.com/de-odex/suru/commit/f6f1e607c585b2bc2f71309996643f0555ff6349)
  - because [this code](https://github.com/de-odex/suru/blob/e99984f309013bb4c0cdc32c59bcadea9d82b948/src/suru.nim#L241)  causes compilation error

## Evidence
### Environment
- OS: macOS montery version 13.1
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8

### Test1
Compile succeed as follows.
```
fukusuke@fukusukenoAir takajo % nimble build -d:release -d:ssl
  Verifying dependencies for takajo@2.0.0
 Installing cligen@>= 1.5
Downloading https://github.com/c-blake/cligen.git using git
  Verifying dependencies for cligen@1.6.13
 Installing cligen@1.6.13
  Success:  cligen installed successfully.
 Installing suru@#f6f1e607c585b2bc2f71309996643f0555ff6349
Downloading https://github.com/de-odex/suru using git
  Verifying dependencies for suru@0.3.1
 Installing suru@0.3.1
  Success:  suru installed successfully.
   Building takajo/takajo using c backend
fukusuke@fukusukenoAir takajo % nim -v                        
Nim Compiler Version 2.0.0 [MacOSX: amd64]
Compiled at 2023-08-19
Copyright (c) 2006-2023 by Andreas Rumpf

active boot switches: -d:release
fukusuke@fukusukenoAir takajo % nimble -v
nimble v0.14.2 compiled at 2023-08-19 16:19:52
git hash: couldn't determine git hash
```

### Test2
I confirmed that the progress bar is displayed correctly as follows.
```
fukusuke@fukusukenoAir hayabusa-2.7.0-all-platforms % ./takajo timeline-logon -t out.jsonl -o logons.csv
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Started the Timeline Logon command

This command creates a CSV timeline of logon events.
Elapsed time for successful logons are calculated by default but can be disabled with -c=false.
Logoff events can be outputted on separate lines with -l, --outputLogoffEvents.
Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.


Counting total lines. Please wait.

Total lines: 1627290

Creating a logon timeline. Please wait.

100%|█████████████████████████| 1627291/1627290 [36.9s< 0.0s,  36.71k/sec]

Calculating logon elapsed time. Please wait.

Found logon events:
EID 4624 (Successful Logon): 334
EID 4625 (Failed Logon): 3
EID 4634 (Logoff): 18
EID 4647 (User Initiated Logoff): 16
EID 4648 (Explicit Logon): 2
EID 4672 (Admin Logon): 291

Saved results to logons.csv (76.00 KB)

Elapsed time: 0 hours, 0 minutes, 38 seconds
```

### Environment
- OS: Windows 11(ARM64)
- VM(on Parallels Desktop 18 for mac)
### Test3
Compile succeed as follows.
```
PS C:\Users\fukusuke\takajo> nimble update
Downloading Official package list
    Success Package list downloaded.
PS C:\Users\fukusuke\takajo> nimble build -d:release -d:ssl
  Verifying dependencies for takajo@2.0.0
     Info:  Dependency on cligen@>= 1.5 already satisfied
  Verifying dependencies for cligen@1.6.13
     Info:  Dependency on suru@#f6f1e607c585b2bc2f71309996643f0555ff6349 already satisfied
  Verifying dependencies for suru@0.3.1
   Building takajo/takajo.exe using c backend
```

I would appreciate it if you could review🙏
