### PR TITLE
feat: make vt lookup multithreaded

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: jiro4989/setup-nim-action@v1
         with:
-          nim-version: '1.x' # default is 'stable'
+          nim-version: '2.x' # default is 'stable'
       - name: Build check
-        run: nimble build -Y
+        run: nimble build --threads:on -Y
       - name: Run tests
-        run: nimble test -Y
+        run: nimble test --threads:on -Y

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -6,6 +6,7 @@
 
 - TakajoがNim 2.0.0でコンパイルできるようになった。(#31) (@fukusuket)
 - 依存関係を減らすため、HTTPクライアントをPuppyに置き換えた。 (#33) (@fukusuket)
+- パフォーマンス向上のため、VirusTotalクエリをマルチスレッドにした。 (#33) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Takajo now compiles with Nim 2.0.0. (#31) (@fukusuket)
 - Replaced HTTP with Puppy to reduce external dependencies. (#33) (@fukusuket)
+- Made VirusTotal lookups multi-threaded to increase performance. (#33) (@fukusuket)
 
 - `list-domains`: create a
 

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -113,7 +113,7 @@ Nimがインストールされている場合、以下のコマンドでソー�
 
 ```
 > nimble update
-> nimble build -d:release
+> nimble build -d:release --threads:on 
 ```
 
 # コマンド一覧

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you have Nim installed, you can compile from source with the following comman
 
 ```
 > nimble update
-> nimble build -d:release
+> nimble build -d:release --threads:on 
 ```
 
 # Command List

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -9,6 +9,7 @@ import strutils
 import tables
 import terminal
 import times
+import threadpool
 import uri
 import os
 import std/enumerate

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -323,3 +323,9 @@ proc extractDomain*(domain: string): string =
 
 proc isLocalIP*(ip: string): bool =
   return ip == "127.0.0.1" or ip == "-" or ip == "::1"
+
+
+type VirusTotalResult* = object
+  resTable*: TableRef[string, string]
+  resJson*: JsonNode
+  isMalicious* : bool

--- a/src/takajopkg/vtDomainLookup.nim
+++ b/src/takajopkg/vtDomainLookup.nim
@@ -1,8 +1,56 @@
 # TODO:
-# Make asynchronous
 # Handle OSError exception when the network gets disconnected while running
 # Add categories and SAN info
 # Add output not found to txt file
+
+var vtAPIDomainChannel: Channel[VirusTotalResult] # channel for receiving parallel query results
+
+proc queryDomainAPI(domain:string, headers: httpheaders.HttpHeaders) {.thread.} =
+    let response = get("https://www.virustotal.com/api/v3/domains/" & encodeUrl(domain), headers)
+    let jsonResponse = parseJson(response.body)
+    var singleResultTable = newTable[string, string]()
+    var malicious = false
+    singleResultTable["Domain"] = domain
+    singleResultTable["Link"] = "https://www.virustotal.com/gui/domain/" & domain
+    if response.code == 200:
+        singleResultTable["Response"] = "200"
+        # Parse values that need epoch time to human readable time
+        singleResultTable["CreationDate"] = getJsonDate(jsonResponse, @["data", "attributes", "creation_date"])
+        singleResultTable["LastAnalysisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_analysis_date"])
+        singleResultTable["LastModifiedDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_modification_date"])
+        singleResultTable["LastWhoisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "whois_date"])
+
+        # Parse simple data
+        singleResultTable["MaliciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "malicious"])
+        singleResultTable["HarmlessCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "harmless"])
+        singleResultTable["SuspiciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "suspicious"])
+        singleResultTable["UndetectedCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "undetected"])
+        singleResultTable["CommunityVotesHarmless"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "harmless"])
+        singleResultTable["CommunityVotesMalicious"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "malicious"])
+        singleResultTable["Reputation"] = getJsonValue(jsonResponse, @["data", "attributes", "reputation"])
+        singleResultTable["Registrar"] = getJsonValue(jsonResponse, @["data", "attributes", "registrar"])
+        singleResultTable["WhoisInfo"] = getJsonValue(jsonResponse, @["data", "attributes", "whois"])
+        singleResultTable["SSL-ValidAfter"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "not_before"])
+        singleResultTable["SSL-ValidUntil"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "not_after"])
+        singleResultTable["SSL-Issuer"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "O"])
+        singleResultTable["SSL-IssuerCountry"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "C"])
+
+        # If it was found to be malicious, print to screen an alert
+        if parseInt(singleResultTable["MaliciousCount"]) > 0:
+            malicious = true
+            echo "\pFound malicious domain: " & domain & " (Malicious count: " & singleResultTable["MaliciousCount"] & " )"
+
+    # If we get a 404 not found
+    elif response.code == 404:
+        echo "\pDomain not found: ", domain
+        singleResultTable["Response"] = "404"
+    else:
+        echo "\pUnknown error: ", intToStr(response.code), " - " & domain
+        singleResultTable["Response"] = intToStr(response.code)
+
+    vtAPIDomainChannel.send(VirusTotalResult(resTable:singleResultTable, resJson:jsonResponse, isMalicious:malicious))
+
+
 proc vtDomainLookup(apiKey: string, domainList: string, jsonOutput: string = "", output: string, rateLimit: int = 4, quiet: bool = false) =
     let startTime = epochTime()
     if not quiet:
@@ -52,57 +100,22 @@ proc vtDomainLookup(apiKey: string, domainList: string, jsonOutput: string = "",
     headers["x-apikey"] = apiKey
     bar[0].total = len(lines)
     bar.setup()
+    vtAPIDomainChannel.open()
 
     for domain in lines:
         inc bar
         bar.update(1000000000) # refresh every second
-        let response = get("https://www.virustotal.com/api/v3/domains/" & encodeUrl(domain), headers)
-        var singleResultTable = newTable[string, string]()
-        singleResultTable["Domain"] = domain
-        singleResultTable["Link"] = "https://www.virustotal.com/gui/domain/" & domain
-        if response.code == 200:
-            singleResultTable["Response"] = "200"
-            let jsonResponse = parseJson(response.body)
-            jsonResponses.add(jsonResponse)
-
-            # Parse values that need epoch time to human readable time
-            singleResultTable["CreationDate"] = getJsonDate(jsonResponse, @["data", "attributes", "creation_date"])
-            singleResultTable["LastAnalysisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_analysis_date"])
-            singleResultTable["LastModifiedDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_modification_date"])
-            singleResultTable["LastWhoisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "whois_date"])
-
-            # Parse simple data
-            singleResultTable["MaliciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "malicious"])
-            singleResultTable["HarmlessCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "harmless"])
-            singleResultTable["SuspiciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "suspicious"])
-            singleResultTable["UndetectedCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "undetected"])
-            singleResultTable["CommunityVotesHarmless"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "harmless"])
-            singleResultTable["CommunityVotesMalicious"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "malicious"])
-            singleResultTable["Reputation"] = getJsonValue(jsonResponse, @["data", "attributes", "reputation"])
-            singleResultTable["Registrar"] = getJsonValue(jsonResponse, @["data", "attributes", "registrar"])
-            singleResultTable["WhoisInfo"] = getJsonValue(jsonResponse, @["data", "attributes", "whois"])
-            singleResultTable["SSL-ValidAfter"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "not_before"])
-            singleResultTable["SSL-ValidUntil"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "not_after"])
-            singleResultTable["SSL-Issuer"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "O"])
-            singleResultTable["SSL-IssuerCountry"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "C"])
-
-            # If it was found to be malicious, print to screen an alert
-            if parseInt(singleResultTable["MaliciousCount"]) > 0:
-                inc totalMaliciousDomainCount
-                echo "\pFound malicious domain: " & domain & " (Malicious count: " & singleResultTable["MaliciousCount"] & " )"
-
-        # If we get a 404 not found
-        elif response.code == 404:
-            echo "\pDomain not found: ", domain
-            singleResultTable["Response"] = "404"
-        else:
-            echo "\pUnknown error: ", intToStr(response.code), " - " & domain
-            singleResultTable["Response"] = intToStr(response.code)
-
-        seqOfResultsTables.add(singleResultTable)
+        spawn queryDomainAPI(domain, headers) # run queries in parallel
 
         # Sleep to respect the rate limit.
         sleep(int(timePerRequest * 1000)) # Convert to milliseconds.
+
+    for domain in lines:
+        let vtResult: VirusTotalResult = vtAPIDomainChannel.recv() # get results of queries executed in parallel
+        seqOfResultsTables.add(vtResult.resTable)
+        jsonResponses.add(vtResult.resJson)
+        if vtResult.isMalicious:
+          totalMaliciousDomainCount += 1
 
     bar.finish()
 

--- a/src/takajopkg/vtDomainLookup.nim
+++ b/src/takajopkg/vtDomainLookup.nim
@@ -117,6 +117,9 @@ proc vtDomainLookup(apiKey: string, domainList: string, jsonOutput: string = "",
         if vtResult.isMalicious:
           totalMaliciousDomainCount += 1
 
+    sync()
+    vtAPIDomainChannel.close()
+
     bar.finish()
 
     echo ""

--- a/src/takajopkg/vtHashLookup.nim
+++ b/src/takajopkg/vtHashLookup.nim
@@ -107,6 +107,10 @@ proc vtHashLookup(apiKey: string, hashList: string, jsonOutput: string = "", out
         if vtResult.isMalicious:
           totalMaliciousHashCount += 1
 
+    sync()
+    vtAPIHashChannel.close()
+
+
     bar.finish()
     echo ""
     echo "Finished querying hashes"

--- a/src/takajopkg/vtIpLookup.nim
+++ b/src/takajopkg/vtIpLookup.nim
@@ -103,6 +103,7 @@ proc vtIpLookup(apiKey: string, ipList: string, jsonOutput: string = "", output:
     headers["x-apikey"] = apiKey
     bar[0].total = len(lines)
     bar.setup()
+    vtIpAddressChannel.open()
 
     for ipAddress in lines:
         inc bar

--- a/src/takajopkg/vtIpLookup.nim
+++ b/src/takajopkg/vtIpLookup.nim
@@ -120,6 +120,9 @@ proc vtIpLookup(apiKey: string, ipList: string, jsonOutput: string = "", output:
         if vtResult.isMalicious:
           totalMaliciousIpAddressCount += 1
 
+    sync()
+    vtIpAddressChannel.close()
+
     bar.finish()
 
     echo ""

--- a/src/takajopkg/vtIpLookup.nim
+++ b/src/takajopkg/vtIpLookup.nim
@@ -1,4 +1,58 @@
 # TODO: add SAN array info
+
+var vtIpAddressChannel: Channel[VirusTotalResult] # channel for receiving parallel query results
+
+proc queryIpAPI(ipAddress:string, headers: httpheaders.HttpHeaders) {.thread.} =
+    let response = get("https://www.virustotal.com/api/v3/ip_addresses/" & ipAddress, headers)
+    let jsonResponse = parseJson(response.body)
+    var singleResultTable = newTable[string, string]()
+    var malicious = false
+    singleResultTable["IP-Address"] = ipAddress
+    singleResultTable["Link"] = "https://www.virustotal.com/gui/ip_addresses/" & ipAddress
+    if response.code == 200:
+        singleResultTable["Response"] = "200"
+
+        # Parse values that need epoch time to human readable time
+        singleResultTable["LastAnalysisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_analysis_date"])
+        singleResultTable["LastModifiedDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_modification_date"])
+        singleResultTable["LastHTTPSCertDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_https_certificate_date"])
+        singleResultTable["LastWhoisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "whois_date"])
+
+        # Parse simple data
+        singleResultTable["MaliciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "malicious"])
+        singleResultTable["HarmlessCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "harmless"])
+        singleResultTable["SuspiciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "suspicious"])
+        singleResultTable["UndetectedCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "undetected"])
+        singleResultTable["CommunityVotesHarmless"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "harmless"])
+        singleResultTable["CommunityVotesMalicious"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "malicious"])
+        singleResultTable["Reputation"] = getJsonValue(jsonResponse, @["data", "attributes", "reputation"])
+        singleResultTable["RegionalInternetRegistry"] = getJsonValue(jsonResponse, @["data", "attributes", "regional_internet_registry"])
+        singleResultTable["WhoisInfo"] = getJsonValue(jsonResponse, @["data", "attributes", "whois"])
+        singleResultTable["Network"] = getJsonValue(jsonResponse, @["data", "attributes", "network"])
+        singleResultTable["Country"] = getJsonValue(jsonResponse, @["data", "attributes", "country"])
+        singleResultTable["AS-Owner"] = getJsonValue(jsonResponse, @["data", "attributes", "as_owner"])
+        singleResultTable["SSL-ValidAfter"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "validity", "not_before"])
+        singleResultTable["SSL-ValidUntil"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "validity", "not_after"])
+        singleResultTable["SSL-Issuer"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "O"])
+        singleResultTable["SSL-IssuerCountry"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "C"])
+        singleResultTable["SSL-CommonName"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "subject", "CN"])
+
+        # If it was found to be malicious
+        if parseInt(singleResultTable["MaliciousCount"]) > 0:
+            malicious = true
+            echo "\pFound malicious IP address: " & ipAddress & " (Malicious count: " & singleResultTable["MaliciousCount"] & " )"
+
+    # If we get a 404 not found
+    elif response.code == 404:
+        echo "\pIP address not found: ", ipAddress
+        singleResultTable["Response"] = "404"
+    else:
+        echo "\pUnknown error: ", intToStr(response.code), " - " & ipAddress
+        singleResultTable["Response"] = intToStr(response.code)
+
+    vtIpAddressChannel.send(VirusTotalResult(resTable:singleResultTable, resJson:jsonResponse, isMalicious:malicious))
+
+
 proc vtIpLookup(apiKey: string, ipList: string, jsonOutput: string = "", output: string, rateLimit: int = 4, quiet: bool = false) =
     let startTime = epochTime()
     if not quiet:
@@ -53,57 +107,17 @@ proc vtIpLookup(apiKey: string, ipList: string, jsonOutput: string = "", output:
     for ipAddress in lines:
         inc bar
         bar.update(1000000000) # refresh every second
-        let response = get("https://www.virustotal.com/api/v3/ip_addresses/" & ipAddress, headers)
-        var singleResultTable = newTable[string, string]()
-        singleResultTable["IP-Address"] = ipAddress
-        singleResultTable["Link"] = "https://www.virustotal.com/gui/ip_addresses/" & ipAddress
-        if response.code == 200:
-            singleResultTable["Response"] = "200"
-            let jsonResponse = parseJson(response.body)
-            jsonResponses.add(jsonResponse)
-
-            # Parse values that need epoch time to human readable time
-            singleResultTable["LastAnalysisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_analysis_date"])
-            singleResultTable["LastModifiedDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_modification_date"])
-            singleResultTable["LastHTTPSCertDate"] = getJsonDate(jsonResponse, @["data", "attributes", "last_https_certificate_date"])
-            singleResultTable["LastWhoisDate"] = getJsonDate(jsonResponse, @["data", "attributes", "whois_date"])
-
-            # Parse simple data
-            singleResultTable["MaliciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "malicious"])
-            singleResultTable["HarmlessCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "harmless"])
-            singleResultTable["SuspiciousCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "suspicious"])
-            singleResultTable["UndetectedCount"] = getJsonValue(jsonResponse, @["data", "attributes", "last_analysis_stats", "undetected"])
-            singleResultTable["CommunityVotesHarmless"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "harmless"])
-            singleResultTable["CommunityVotesMalicious"] = getJsonValue(jsonResponse, @["data", "attributes", "total_votes", "malicious"])
-            singleResultTable["Reputation"] = getJsonValue(jsonResponse, @["data", "attributes", "reputation"])
-            singleResultTable["RegionalInternetRegistry"] = getJsonValue(jsonResponse, @["data", "attributes", "regional_internet_registry"])
-            singleResultTable["WhoisInfo"] = getJsonValue(jsonResponse, @["data", "attributes", "whois"])
-            singleResultTable["Network"] = getJsonValue(jsonResponse, @["data", "attributes", "network"])
-            singleResultTable["Country"] = getJsonValue(jsonResponse, @["data", "attributes", "country"])
-            singleResultTable["AS-Owner"] = getJsonValue(jsonResponse, @["data", "attributes", "as_owner"])
-            singleResultTable["SSL-ValidAfter"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "validity", "not_before"])
-            singleResultTable["SSL-ValidUntil"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "validity", "not_after"])
-            singleResultTable["SSL-Issuer"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "O"])
-            singleResultTable["SSL-IssuerCountry"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "issuer", "C"])
-            singleResultTable["SSL-CommonName"] = getJsonValue(jsonResponse, @["data", "attributes", "last_https_certificate", "subject", "CN"])
-
-            # If it was found to be malicious
-            if parseInt(singleResultTable["MaliciousCount"]) > 0:
-                inc totalMaliciousIpAddressCount
-                echo "\pFound malicious IP address: " & ipAddress & " (Malicious count: " & singleResultTable["MaliciousCount"] & " )"
-
-        # If we get a 404 not found
-        elif response.code == 404:
-            echo "\pIP address not found: ", ipAddress
-            singleResultTable["Response"] = "404"
-        else:
-            echo "\pUnknown error: ", intToStr(response.code), " - " & ipAddress
-            singleResultTable["Response"] = intToStr(response.code)
-
-        seqOfResultsTables.add(singleResultTable)
+        spawn queryIpAPI(ipAddress, headers) # run queries in parallel
 
         # Sleep to respect the rate limit.
         sleep(int(timePerRequest * 1000)) # Convert to milliseconds.
+
+    for ipAddress in lines:
+        let vtResult: VirusTotalResult = vtIpAddressChannel.recv() # get results of queries executed in parallel
+        seqOfResultsTables.add(vtResult.resTable)
+        jsonResponses.add(vtResult.resJson)
+        if vtResult.isMalicious:
+          totalMaliciousIpAddressCount += 1
 
     bar.finish()
 


### PR DESCRIPTION
## What Changed

- Feat  #30
- Make VirusTotal API lookup multithreaded
   - Start a thread for each VirusTotal API query request  
      - Using a thread from the thread pool with [spawn](https://nim-by-example.github.io/parallelism/)
   - API query results executed in multithread are stored in [Channel](https://nim-by-example.github.io/channels/)
      - The reason I used a Channel is so that we can receive the results thread-safely.
      - [In Nim, Channel cannot be a proc argument, so define it in the global scope](https://nim-lang.org/docs/manual_experimental.html#parallel-amp-spawn-spawn-statement) 

I have confirmed the following behavior: https://github.com/Yamato-Security/takajo/pull/34#issuecomment-1703971022
However, I'm sorry, since my API is a free version :( I haven't checked to see if it's faster... If possible, I would appreciate it if you could see if it is faster🙏
