### PR TITLE
fix: `timeline-suspicious-process` command `Error: unhandled exception: invalid hex integer: [ValueError]`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,6 +7,10 @@
 - TakajoがNim 2.0.0でコンパイルできるようになった。(#31) (@fukusuket)
 - 依存関係を減らすため、HTTPクライアントをPuppyに置き換えた。 (#33) (@fukusuket)
 
+**バグ修正*:**
+
+- Hayabusa 2.8.0以上の結果で`timeline-suspicious-processes`を実行した際のクラッシュを修正した。 (#35) (@fukusuket)
+
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 
 **新機能:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Takajo now compiles with Nim 2.0.0. (#31) (@fukusuket)
 - Replaced HTTP with Puppy to reduce external dependencies. (#33) (@fukusuket)
 
-- `list-domains`: create a
+**Bug Fixes*:**
+
+- `timeline-suspicious-processes` would crash when Hayabusa results from version 2.8.0+ was used. (#35) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -60,7 +60,10 @@ proc timelineSuspiciousProcesses(level: string = "high", output: string = "", qu
             computer = jsonLine["Computer"].getStr()
             process = jsonLine["Details"]["Proc"].getStr()
             pidStr = jsonLine["Details"]["PID"].getStr()
-            pidStr = intToStr(fromHex[int](pidStr))
+            try:
+              pidStr = intToStr(fromHex[int](pidStr))
+            except ValueError:
+              discard # conversion errors in fromHex are assumed to have originally been decimal.
             user = jsonLine["Details"]["User"].getStr()
             lid = jsonLine["Details"]["LID"].getStr()
             try:


### PR DESCRIPTION
## What Changed

- Fixed  #35
  - If conversion fails with `fromHex`, consider it as a decimal number

### Environment1
- OS: macOS montery version 13.4.1
- Hard: MacBook Air(M1, 2020) , Memory 8GB, Core 8
```
% nim -v
Nim Compiler Version 2.0.0 [MacOSX: amd64]
% nimble -v
nimble v0.14.2 compiled at 2023-08-19 16:19:52
```
### Test
`timeline-suspicious-process` command success.
```
fukusuke@fukusukenoMacBook-Air hayabusa-2.8.0-all-platforms % ./takajo timeline-suspicious-processes -t result.jsonl -o out.txt
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Started the Timeline Suspicious Processes command

This command will a CSV timeline of suspicious processes.
The default minimum level of alerts is high.
You can change the minimum level with -l, --level=.

Counting total lines. Please wait.

Total lines: 32265

Scanning for processes with a minimal alert level of high

100%|█████████████████████████| 32266/32265 [ 0.5s< 0.0s, 105.76k/sec]
Saved results to out.txt (729.93 KB)

Suspicous processes in Security 4688 process creation events: 346
Suspicious processes in Sysmon 1 process creation events: 439

Elapsed time: 0 hours, 0 minutes, 0 seconds
```


I would appreciate it if you could review when you have time🙏


