### PR TITLE
fix: `JsonParsingError` when `vt-lookup` failed with invalid api key

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -11,6 +11,7 @@
 **バグ修正*:**
 
 - Hayabusa 2.8.0以上の結果で`timeline-suspicious-processes`を実行した際のクラッシュを修正した。 (#35) (@fukusuket)
+- 無効なAPIキーが指定された場合に、VirusTotalの検索でJSONパースエラーが発生する問題を修正した。(@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 **Bug Fixes*:**
 
 - `timeline-suspicious-processes` would crash when Hayabusa results from version 2.8.0+ was used. (#35) (@fukusuket)
+- Fixed a JSON parsing error in VirusTotal lookups when an invalid API key was specified. (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/src/takajopkg/vtDomainLookup.nim
+++ b/src/takajopkg/vtDomainLookup.nim
@@ -7,12 +7,13 @@ var vtAPIDomainChannel: Channel[VirusTotalResult] # channel for receiving parall
 
 proc queryDomainAPI(domain:string, headers: httpheaders.HttpHeaders) {.thread.} =
     let response = get("https://www.virustotal.com/api/v3/domains/" & encodeUrl(domain), headers)
-    let jsonResponse = parseJson(response.body)
+    var jsonResponse = %* {}
     var singleResultTable = newTable[string, string]()
     var malicious = false
     singleResultTable["Domain"] = domain
     singleResultTable["Link"] = "https://www.virustotal.com/gui/domain/" & domain
     if response.code == 200:
+        jsonResponse = parseJson(response.body)
         singleResultTable["Response"] = "200"
         # Parse values that need epoch time to human readable time
         singleResultTable["CreationDate"] = getJsonDate(jsonResponse, @["data", "attributes", "creation_date"])

--- a/src/takajopkg/vtHashLookup.nim
+++ b/src/takajopkg/vtHashLookup.nim
@@ -1,18 +1,18 @@
-# Todo: add more info useful for triage, trusted_verdict, signature info, sandbox results etc...
+# TODO: add more info useful for triage, trusted_verdict, signature info, sandbox results etc...
 # https://blog.virustotal.com/2021/08/introducing-known-distributors.html
-# TODO:
 # Add output not found to txt file
 
 var vtAPIHashChannel: Channel[VirusTotalResult] # channel for receiving parallel query results
 
 proc queryHashAPI(hash:string, headers: httpheaders.HttpHeaders) {.thread.} =
     let response = get("https://www.virustotal.com/api/v3/files/" & hash, headers)
-    let jsonResponse = parseJson(response.body)
+    var jsonResponse = %* {}
     var singleResultTable = newTable[string, string]()
     var malicious = false
     singleResultTable["Hash"] = hash
     singleResultTable["Link"] = "https://www.virustotal.com/gui/file/" & hash
     if response.code == 200:
+        jsonResponse = parseJson(response.body)
         singleResultTable["Response"] = "200"
 
         # Parse values that need epoch time to human readable time

--- a/src/takajopkg/vtIpLookup.nim
+++ b/src/takajopkg/vtIpLookup.nim
@@ -4,12 +4,13 @@ var vtIpAddressChannel: Channel[VirusTotalResult] # channel for receiving parall
 
 proc queryIpAPI(ipAddress:string, headers: httpheaders.HttpHeaders) {.thread.} =
     let response = get("https://www.virustotal.com/api/v3/ip_addresses/" & ipAddress, headers)
-    let jsonResponse = parseJson(response.body)
+    var jsonResponse = %* {}
     var singleResultTable = newTable[string, string]()
     var malicious = false
     singleResultTable["IP-Address"] = ipAddress
     singleResultTable["Link"] = "https://www.virustotal.com/gui/ip_addresses/" & ipAddress
     if response.code == 200:
+        jsonResponse = parseJson(response.body)
         singleResultTable["Response"] = "200"
 
         # Parse values that need epoch time to human readable time


### PR DESCRIPTION
## What Changed
- Fixed  #39

### Environment1
- OS: macOS montery version 13.4.1
```
% nim -v
Nim Compiler Version 2.0.0 [MacOSX: amd64]
% nimble -v
nimble v0.14.2 compiled at 2023-08-19 16:19:52
```
### Test
`vt-domain-lookup` command with invalid api key does not fail as follows.
```
./takajo-new vt-domain-lookup -a invalidkey --domainList domain.txt -o out.csv
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Started the VirusTotal Domain Lookup command

This command will lookup a list of domains on VirusTotal.
Specify -j results.json to save the original JSON responses.
The default rate is 4 requests per minute so increase this if you have a premium membership.

Loading domains. Please wait.

Loaded domains: 2
Rate limit per minute: 4

Estimated time: 0 hours, 0 minutes, 30 seconds

  0%|                         | 0/2 [ 0.0s<  ??s,      ??/sec]
Unknown error: 0 - example.com
100%|█████████████████████████| 2/2 [15.0s< 0.0s,  83.16m/sec]
Unknown error: 0 - invalid
100%|█████████████████████████| 2/2 [30.0s< 0.0s,  83.16m/sec]

Finished querying domains
Malicious domains found: 0
Saved CSV results to out.csv (0 Bytes)

Elapsed time: 0 hours, 0 minutes, 30 seconds
```

### Notes
I created an issue https://github.com/treeform/puppy/issues/110 because `Puppy` was the cause of the response code being `0(Unknown error: 0)` instead of `401 Unauthorized`.

I would appreciate it if you could review when you have time🙏
