### PR TITLE
fix duplicate process output `sysmon-process-tree`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -14,6 +14,7 @@
 
 - Hayabusa 2.8.0以上の結果で`timeline-suspicious-processes`を実行した際のクラッシュを修正した。 (#35) (@fukusuket)
 - 無効なAPIキーが指定された場合に、VirusTotalの検索でJSONパースエラーが発生する問題を修正した。(@fukusuket)
+- `sysmon-process-tree`コマンドでプロセス情報が2回出力されることがあるバグを修正した。(#52) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `timeline-suspicious-processes` would crash when Hayabusa results from version 2.8.0+ was used. (#35) (@fukusuket)
 - Fixed a JSON parsing error in VirusTotal lookups when an invalid API key was specified. (@fukusuket)
+- Fixed a bug in `sysmon-process-tree` in which process information would sometimes be outputted twice. (#52) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -31,7 +31,7 @@ include takajopkg/vtIpLookup
 include takajopkg/vtHashLookup
 
 when isMainModule:
-    clCfg.version = "2.0.0"
+    clCfg.version = "2.1.0-dev"
     const examples = "Examples:\p"
     const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl -o domains.txt\p"
     const example_list_ip_addresses = "  list-ip-addresses -t ../hayabusa/timeline.jsonl -o ipAddresses.txt\p"
@@ -48,7 +48,7 @@ when isMainModule:
     const example_vt_hash_lookup = "  vt-hash-lookup -a <API-KEY> --hashList case-1-MD5-hashes.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
     const example_vt_ip_lookup = "  vt-ip-lookup -a <API-KEY> --ipList ipAddresses.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
 
-    clCfg.useMulti = "Version: 2.0.0\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
+    clCfg.useMulti = "Version: 2.1.0-dev\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
         examples & example_list_domains & example_list_hashes & example_list_ip_addresses & example_list_undetected_evtx & example_list_unused_rules &
         example_split_csv_timeline & example_split_json_timeline & example_stack_logons & example_sysmon_process_tree &
         example_timeline_logon & example_timeline_suspicious_processes &

--- a/src/takajopkg/sysmonProcessTree.nim
+++ b/src/takajopkg/sysmonProcessTree.nim
@@ -42,13 +42,6 @@ proc printIndentedProcessTree(p: processObject, indent: string = "",
                 childStairNum, next_need_sameStair, childNum + 1 == len(p.children)))
     return ret
 
-proc containsTargetGUIDInChild(p: processObject, targetGUID: string): bool =
-    for child in p.children:
-        if child.processGUID == targetGUID:
-            return true
-    return false
-
-
 proc moveProcessObjectToChild(mvSourceProcess: processObject,
         searchProcess: var processObject,
                 outputProcess: var processObject) =
@@ -117,14 +110,8 @@ proc sysmonProcessTree(output: string = "", processGuid: string,
                 parentsProcesStockDisableFlag = true
                 inc processesFoundCount
                 let keysToExtract = {
-                    #"CmdLine": "Cmdline",
                     "Proc": "Proc",
-                    #"ParentCmdline": "ParentCmdline",
-                    #"LogonID": "LID",
-                    #"LogonGUID": "LGUID",
-                    #"ParentPID": "ParentPID",
                     "ParentPGUID": "ParentPGUID",
-                    #"Hashes": "Hashes"
                 }
 
                 for (foundKey, jsonKey) in keysToExtract:
@@ -195,14 +182,8 @@ proc sysmonProcessTree(output: string = "", processGuid: string,
         if eventProcessGUID in passGuid:
             var processObjectTable = newTable[string, processObject]()
             let keysToExtract = {
-                #"CmdLine": "Cmdline",
                 "Proc": "Proc",
-                #"ParentCmdline": "ParentCmdline",
-                #"LogonID": "LID",
-                #"LogonGUID": "LGUID",
-                #"ParentPID": "ParentPID",
                 "ParentPGUID": "ParentPGUID",
-                #"Hashes": "Hashes"
             }
 
             for (foundKey, jsonKey) in keysToExtract:

--- a/src/takajopkg/sysmonProcessTree.nim
+++ b/src/takajopkg/sysmonProcessTree.nim
@@ -7,6 +7,9 @@ type
         parentProcessGUID: string
         children: seq[processObject]
 
+proc `==`*(a, b: processObject): bool =
+  return a.processGUID == b.processGUID
+
 proc printIndentedProcessTree(p: processObject, indent: string = "",
         stairNum: int = 0, need_sameStair: seq[bool], parentsStair: bool): seq[string] =
     ## プロセスオブジェクトからプロセスツリーを画面上に表示するためのプロシージャ
@@ -52,6 +55,7 @@ proc moveProcessObjectToChild(mvSourceProcess: processObject,
         if childProcess.processGUID == mvSourceProcess.parentProcessGUID:
             # Added to a separate table because assertion errors occur when the number of elements changes during iteration
             outputProcess.children[idx].children.add(mvSourceProcess)
+            outputProcess.children[idx].children = deduplicate(outputProcess.children[idx].children)
             return
         else:
             var child = childProcess

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.0.0"
+version       = "2.1.0"
 author        = "Yamato Security @SecurityYamato"
 description   = "Takajo is an analyzer for Hayabusa results."
 license       = "GPL-3.0"


### PR DESCRIPTION
## What Changed
- Fixed #51
  - Remove duplicates `processObject` when moving `processObject` to children 

## Test

### Environment
- OS: macOS Sonoma version 14.0
```
% nim -v
Nim Compiler Version 2.0.0 [MacOSX: amd64]
% nimble -v
nimble v0.14.2 compiled at 2023-08-19 16:19:52
```
### Test1

Duplicate processes are not displayed in the steps to reproduce #51
```
% ./takajo sysmon-process-tree -t sample.jsonl -p 747F3D96-B7A5-5EA4-0000-0010EAB91300
...

C:\Windows\System32\smss.exe (2020-04-26 07:19:20.134 +09:00 / 300 / 747F3D96-B75F-5EA4-0000-0010622C0000 / 747F3D96-B75F-5EA4-0000-0010EB030000)
  └ C:\Windows\System32\smss.exe (2020-04-26 07:19:22.596 +09:00 / 388 / 747F3D96-B763-5EA4-0000-00106A480000 / 747F3D96-B75F-5EA4-0000-0010622C0000)
      └ C:\Windows\System32\wininit.exe (2020-04-26 07:19:23.222 +09:00 / 468 / 747F3D96-B764-5EA4-0000-0010904D0000 / 747F3D96-B763-5EA4-0000-00106A480000)
          └ C:\Windows\System32\services.exe (2020-04-26 07:19:24.049 +09:00 / 584 / 747F3D96-B764-5EA4-0000-00106F550000 / 747F3D96-B764-5EA4-0000-0010904D0000)
              └ C:\Windows\System32\svchost.exe (2020-04-26 07:19:40.692 +09:00 / 6964 / 747F3D96-B776-5EA4-0000-0010A74D0B00 / 747F3D96-B764-5EA4-0000-00106F550000)
                  └ C:\Windows\System32\consent.exe (2020-04-26 07:20:21.263 +09:00 / 7036 / 747F3D96-B7A5-5EA4-0000-0010EAB91300 / 747F3D96-B776-5EA4-0000-0010A74D0B00)
```
I found issue #51 during testing, but I think it would be better to fix it in a separate pull request.
I would appreciate it if you could review when you have time🙏