### PR TITLE
fix: not output an exception when a `PGUID` that does not exist in JSONL

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -16,6 +16,7 @@
 - 無効なAPIキーが指定された場合に、VirusTotalの検索でJSONパースエラーが発生する問題を修正した。(@fukusuket)
 - `sysmon-process-tree`コマンドでプロセス情報が2回出力されることがあるバグを修正した。(#52) (@fukusuket)
 - `timeline-suspicious-processes`が`ParentPGUID`フィールドを正しく出力していなかったので修正した。また、PIDの10進数変換を改善した。(#50) (@fukusuket)
+- 指定された`PGUID`が無効であるか、JSONL タイムラインに存在しない場合にエラーが発生する問題を修正した。 (#53) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed a JSON parsing error in VirusTotal lookups when an invalid API key was specified. (@fukusuket)
 - Fixed a bug in `sysmon-process-tree` in which process information would sometimes be outputted twice. (#52) (@fukusuket)
 - `timeline-suspicious-processes` was not correctly outputting `ParentPGUID` field. Improved PID decimal conversion. (#50) (@fukusuket)
+- Fixed an error when the the specified `PGUID` was invalid or does not exist in the JSONL timeline. (#53) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed a JSON parsing error in VirusTotal lookups when an invalid API key was specified. (@fukusuket)
 - Fixed a bug in `sysmon-process-tree` in which process information would sometimes be outputted twice. (#52) (@fukusuket)
 - `timeline-suspicious-processes` was not correctly outputting `ParentPGUID` field. Improved PID decimal conversion. (#50) (@fukusuket)
-- Fixed an error when the the specified `PGUID` was invalid or does not exist in the JSONL timeline. (#53) (@fukusuket)
+- Fixed an error when the specified `PGUID` was invalid or does not exist in the JSONL timeline. (#53) (@fukusuket)
 
 ## 2.0.0 [2022/08/03] - [SANS DFIR Summit 2023 Release](https://www.sans.org/cyber-security-training-events/digital-forensics-summit-2023/)
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -2,6 +2,7 @@ import algorithm
 import cligen
 import json
 import puppy
+import re
 import sets
 import sequtils
 import strformat


### PR DESCRIPTION
## What Changed
- Fixed #53
  - Added [Process GUID format](https://learn.microsoft.com/en-us/windows/win32/msi/guid) check for invalid input(`-p` option)
  - Added a check to see if the specified `Process GUID`(with `-p`) exists in `stockedProcessObjectTable`
    - Not present in s`tockedProcessObjectTable` equals not present in JSONL

## Test

### Environment
- OS: macOS Sonoma version 14.0
```
% nim -v
Nim Compiler Version 2.0.0 [MacOSX: amd64]
% nimble -v
nimble v0.14.2 compiled at 2023-08-19 16:19:52
```
### Test1(Wrong format `Process GUID`)
If a `Process GUID` in the wrong format is specified with `-p`, the following message will be output:
```
% ./takajo sysmon-process-tree -t timeline.jsonl -p invalid -q
The format of the Process GUID specified with the -p option is invalid. Please specify a valid Process GUID.
```

### Test2(Not  exists `Process GUID`)
If a `Process GUID` not exists in JSONL is specified with `-p`, the following message will be output:
```
% ./takajo sysmon-process-tree -t timeline.jsonl -p invalid -p 00000000-0000-0000-0000-000000000000 -q

Running the Process Tree module

The process was not found.
```

### Test3(Exists Child `Process GUID`)
The process tree is displayed as below.
```
% ./takajo sysmon-process-tree -t timeline.jsonl -p 747F3D96-B7A5-5EA4-0000-0010EAB91300 -q

Running the Process Tree module

C:\Windows\System32\smss.exe (2020-04-26 07:19:20.134 +09:00 / 300 / 747F3D96-B75F-5EA4-0000-0010622C0000 / 747F3D96-B75F-5EA4-0000-0010EB030000)
  └ C:\Windows\System32\smss.exe (2020-04-26 07:19:22.596 +09:00 / 388 / 747F3D96-B763-5EA4-0000-00106A480000 / 747F3D96-B75F-5EA4-0000-0010622C0000)
      └ C:\Windows\System32\wininit.exe (2020-04-26 07:19:23.222 +09:00 / 468 / 747F3D96-B764-5EA4-0000-0010904D0000 / 747F3D96-B763-5EA4-0000-00106A480000)
          └ C:\Windows\System32\services.exe (2020-04-26 07:19:24.049 +09:00 / 584 / 747F3D96-B764-5EA4-0000-00106F550000 / 747F3D96-B764-5EA4-0000-0010904D0000)
              └ C:\Windows\System32\svchost.exe (2020-04-26 07:19:40.692 +09:00 / 6964 / 747F3D96-B776-5EA4-0000-0010A74D0B00 / 747F3D96-B764-5EA4-0000-00106F550000)
                  └ C:\Windows\System32\consent.exe (2020-04-26 07:20:21.263 +09:00 / 7036 / 747F3D96-B7A5-5EA4-0000-0010EAB91300 / 747F3D96-B776-5EA4-0000-0010A74D0B00)
```

### Test4(Exists Parent `Process GUID`)
The process tree is displayed as below.
```
% ./takajo sysmon-process-tree -t timeline.jsonl -p 747F3D96-B776-5EA4-0000-0010A74D0B00 -q

Running the Process Tree module

C:\Windows\System32\smss.exe (2020-04-26 07:19:20.134 +09:00 / 300 / 747F3D96-B75F-5EA4-0000-0010622C0000 / 747F3D96-B75F-5EA4-0000-0010EB030000)
  └ C:\Windows\System32\smss.exe (2020-04-26 07:19:22.596 +09:00 / 388 / 747F3D96-B763-5EA4-0000-00106A480000 / 747F3D96-B75F-5EA4-0000-0010622C0000)
      └ C:\Windows\System32\wininit.exe (2020-04-26 07:19:23.222 +09:00 / 468 / 747F3D96-B764-5EA4-0000-0010904D0000 / 747F3D96-B763-5EA4-0000-00106A480000)
          └ C:\Windows\System32\services.exe (2020-04-26 07:19:24.049 +09:00 / 584 / 747F3D96-B764-5EA4-0000-00106F550000 / 747F3D96-B764-5EA4-0000-0010904D0000)
              ├ C:\Windows\System32\svchost.exe (2020-04-26 07:21:19.629 +09:00 / 1396 / 747F3D96-B7DF-5EA4-0000-001080711800 / 747F3D96-B764-5EA4-0000-00106F550000)
              ├ C:\Windows\System32\svchost.exe (2020-04-26 07:19:40.692 +09:00 / 6964 / 747F3D96-B776-5EA4-0000-0010A74D0B00 / 747F3D96-B764-5EA4-0000-00106F550000)
              │  ├ C:\Windows\System32\consent.exe (2020-04-26 07:20:11.402 +09:00 / 6648 / 747F3D96-B79B-5EA4-0000-001075DA0F00 / 747F3D96-B776-5EA4-0000-0010A74D0B00)
              │  └ C:\Windows\System32\consent.exe (2020-04-26 07:20:21.263 +09:00 / 7036 / 747F3D96-B7A5-5EA4-0000-0010EAB91300 / 747F3D96-B776-5EA4-0000-0010A74D0B00)
              ├ C:\Windows\System32\svchost.exe (2020-04-26 07:21:08.564 +09:00 / 2792 / 747F3D96-B7D4-5EA4-0000-0010E09B1700 / 747F3D96-B764-5EA4-0000-00106F550000)
              ├ C:\Windows\System32\svchost.exe (2020-04-26 07:21:19.340 +09:00 / 992 / 747F3D96-B7DF-5EA4-0000-001052671800 / 747F3D96-B764-5EA4-0000-00106F550000)
              ├ C:\Windows\System32\SecurityHealthService.exe (2020-04-26 07:20:16.165 +09:00 / 7088 / 747F3D96-B7A0-5EA4-0000-001027D81000 / 747F3D96-B764-5EA4-0000-00106F550000)
              └ C:\Windows\System32\svchost.exe (2020-04-26 07:21:18.412 +09:00 / 6548 / 747F3D96-B7DE-5EA4-0000-0010FA4E1800 / 747F3D96-B764-5EA4-0000-00106F550000)
```

I would appreciate it if you could review when you have time🙏