### PR TITLE
fix: increment count for last line without `\n`

### DIFF
--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -214,12 +214,6 @@ proc elevatedTokenIdToName*(elevatedTokenId: string): string =
     return result
 
 proc countLinesInTimeline*(filePath: string): int =
-    #[
-    var count = 0
-    for _ in filePath.lines():
-        inc count
-    return count
-    ]#
     const BufferSize = 4 * 1024 * 1024  # 4 MiB
     var buffer = newString(BufferSize)
     var file = open(filePath)
@@ -232,7 +226,7 @@ proc countLinesInTimeline*(filePath: string): int =
         for i in 0 ..< bytesRead:
             if buffer[i] == '\n':
                 inc(count)
-
+    inc(count)
     file.close()
     return count
 

--- a/src/takajopkg/splitCsvTimeline.nim
+++ b/src/takajopkg/splitCsvTimeline.nim
@@ -38,6 +38,7 @@ proc splitCsvTimeline(makeMultiline: bool = false, output: string = "output", qu
 
     # Read in the CSV header
     let csvHeader = inputFile.readLine()
+    inc bar
     while inputFile.endOfFile == false:
         inc bar
         bar.update(1000000000) # refresh every second
@@ -67,6 +68,7 @@ proc splitCsvTimeline(makeMultiline: bool = false, output: string = "output", qu
             outputFile.write(currentLine)
         outputFile.write("\p")
         flushFile(outputFile)
+    inc bar
     bar.finish()
 
     # Close all opened files


### PR DESCRIPTION
## What Changed
- fixed #58

## Test

### Environment
- OS: macOS Sonoma version 14.0
- Hayabusa v2.10.0-dev
- Nim: 2.0.0

### Test1
I performed [the reproduction steps](https://github.com/Yamato-Security/takajo/issues/58#issue-1955748988) and confirmed that the issue was fixed as shown below.
```
% ./takajo list-domains -t timeline-ps.jsonl -o domains.txt -q
Started the List Domains command

Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations.
Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains.
Domains ending with .lan, .LAN or .local are filtered out.

Counting total lines. Please wait.

Total lines: 149

Extracting domain queries from Sysmon 22 events. Please wait.

100%|█████████████████████████| 149/149 [ 0.0s< 0.0s,  44.60k/sec]

Domains: 0
Saved file: domains.txt (0 Bytes)

Elapsed time: 0 hours, 0 minutes, 0 seconds
```

### Test2
I confirmed that the numbers are correct even in CSV format.
```
% ./takajo split-csv-timeline -t timeline.csv -q
Started the Split CSV Timeline command

This command will split a large CSV timeline into many multiple ones based on computer name.
If you want to separate the field data by newlines, add the -m option.

Counting total lines. Please wait.

Total lines: 32251

Splitting the Hayabusa CSV timeline. Please wait.

100%|█████████████████████████| 32251/32251 [ 0.2s< 0.0s, 172.07k/sec]
...
```

I would appreciate it if you could review when you have time🙏