### PR TITLE
fix typo in `timeline-suspicious-process` command console message

### DIFF
--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -232,6 +232,7 @@ proc timelineSuspiciousProcesses(level: string = "high", output: string = "", qu
         echo ""
 
     if suspicousProcessCount_Sec_4688 == 0 and suspicousProcessCount_Sysmon_1 == 0:
+        echo ""
         echo "No suspicous processes were found. There are either no malicious processes or you need to change the level."
         echo ""
         return

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -17,7 +17,7 @@ proc timelineSuspiciousProcesses(level: string = "high", output: string = "", qu
 
     echo "Started the Timeline Suspicious Processes command"
     echo ""
-    echo "This command will a CSV timeline of suspicious processes."
+    echo "This command will create a CSV timeline of suspicious processes."
     echo "The default minimum level of alerts is high."
     echo "You can change the minimum level with -l, --level=."
     echo ""


### PR DESCRIPTION
## What Changed
Fixed typo in `timeline-suspicious-process` command console message.
- https://github.com/Yamato-Security/takajo/issues/35#issuecomment-1777201074
  -  `This command will ...(word missing here) a CSV timeline of suspicious processes`

### Environment
- OS: macOS Sonoma version 14.0
- Hayabusa v2.10.0-dev
- Nim: 2.0.0

### Test
Folloing typo message fixed as follows.
`This command will a CSV timeline of suspicious processes.`
↓
`This command will create a CSV timeline of suspicious processes.`
```
% ./takajo timeline-suspicious-processes -t timeline-ps.jsonl -q
Started the Timeline Suspicious Processes command

This command will create a CSV timeline of suspicious processes.
The default minimum level of alerts is high.
You can change the minimum level with -l, --level=.

Counting total lines. Please wait.

Total lines: 346

Scanning for processes with a minimal alert level of high

100%|█████████████████████████| 346/346 [ 0.1s< 0.0s,  79.26k/sec]
No suspicous processes were found. There are either no malicious processes or you need to change the level.
```

I would appreciate it if you could review when you have time🙏