### PR TITLE
fix: add handling for CSV parse exception

### DIFF
--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -89,9 +89,11 @@ proc getHayabusaCsvData*(csvPath: string, columnName: string): Tableref[string, 
 
     # parse csv
     var p: CsvParser
-    open(p, s, csvPath)
-    p.readHeaderRow()
-
+    try:
+        open(p, s, csvPath)
+        p.readHeaderRow()
+    except:
+        quit("Failed to open '" & csvPath & "' because it is not in CSV format.\nPlease specify a CSV that has been created with the Hayabusa csv-timeline command.")
     let r = newTable[string, seq[string]]()
     # initialize table
     for h in items(p.headers):


### PR DESCRIPTION
## What Changed
- fixed #63 

## Test

### Environment
- OS: macOS Sonoma version 14.0
- Hayabusa v2.10.0
- Nim: 2.2.0-dev

### Test
% ./takajo list-undetected-evtx -t out.jsonl -e ../hayabusa-sample-evtx
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Failed to open 'out.jsonl' because it is not in CSV format.
Please specify a CSV that has been created with the Hayabusa csv-timeline command.

% ./takajo list-unused-rules -t out.jsonl -r ./rules
╔════╦═══╦╗╔═╦═══╗ ╔╦═══╗
║╔╗╔╗║╔═╗║║║╔╣╔═╗║ ║║╔═╗║
╚╝║║╚╣║ ║║╚╝╝║║ ║║ ║║║ ║║
  ║║ ║╚═╝║╔╗╖║╚═╝╠╗║║║ ║║
 ╔╝╚╗║╔═╗║║║╚╣╔═╗║╚╝║╚═╝║
 ╚══╝╚╝ ╚╩╝╚═╩╝ ╚╩══╩═══╝
  by Yamato Security

Failed to open 'out.jsonl' because it is not in CSV format.
Please specify a CSV that has been created with the Hayabusa csv-timeline command.
```