### PR TITLE
feat: add timeline-partition-diagnostic command

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -4,7 +4,7 @@
 
 **新機能:**
 
-- Added `timeline-partition-diagnostic` command to parse the Windows 10 `Microsoft-Windows-Partition%4Diagnostic.evtx` log file and report information about all the connected devices and their Volume Serial Numbers, both currently present on the device and previously existed. (Based on https://github.com/theAtropos4n6/Partition-4DiagnosticParser) (#70) (@fukusuket)
+- Windows10の`Microsoft-Windows-Partition%4Diagnostic.evtx`を解析し、接続されたすべてのデバイスおよびそれらのボリュームシリアル番号に関する情報を出力する`timeline-partition-diagnostic`コマンドを追加した。現在および過去に接続されたデバイスに関する情報を出力する。 (処理は https://github.com/theAtropos4n6/Partition-4DiagnosticParser を参考に作成された) (#70) (@fukusuket)
 
 **改善:**
 

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,7 +2,11 @@
 
 ## x.x.x [xxxx/xx/xx]
 
-**バグ修正*:**
+**新機能:**
+
+- Added `timeline-partition-diagnostic` command to parse the Windows 10 `Microsoft-Windows-Partition%4Diagnostic.evtx` log file and report information about all the connected devices and their Volume Serial Numbers, both currently present on the device and previously existed. (Based on https://github.com/theAtropos4n6/Partition-4DiagnosticParser) (#70) (@fukusuket)
+
+**バグ修正:**
 
 - キーが存在しない場合の未処理の例外のバグを修正した。 (#65) (@fukusuket)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## x.x.x [xxxx/xx/xx]
 
+**New Features:**
+
+- Added `timeline-partition-diagnostic` command to parse the Windows 10 `Microsoft-Windows-Partition%4Diagnostic.evtx` log file and report information about all the connected devices and their Volume Serial Numbers, both currently present on the device and previously existed. (Based on https://github.com/theAtropos4n6/Partition-4DiagnosticParser) (#70) (@fukusuket)
+
 **Bug Fixes*:**
 
 - Fixed an unhandled exception bug when key is not found. (#65) (@fukusuket)

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -29,6 +29,7 @@ include takajopkg/stackLogons
 include takajopkg/listHashes
 include takajopkg/sysmonProcessTree
 include takajopkg/timelineLogon
+include takajopkg/timelinePartitionDiagnostic
 include takajopkg/timelineSuspiciousProcesses
 include takajopkg/vtDomainLookup
 include takajopkg/vtIpLookup
@@ -48,6 +49,7 @@ when isMainModule:
     const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl -o case-1\p"
     const example_sysmon_process_tree = "  sysmon-process-tree -t ../hayabusa/timeline.jsonl -p <Process GUID> [-o process-tree.txt]\p"
     const example_timeline_logon = "  timeline-logon -t ../hayabusa/timeline.jsonl -o logon-timeline.csv\p"
+    const example_timeline_partition_diagnostic = "  timeline-partition-diagnostic -t ../hayabusa/timeline.jsonl -o partition-diagnostic-timeline.csv\p"
     const example_timeline_suspicious_processes = "  timeline-suspicious-processes -t ../hayabusa/timeline.jsonl [--level medium] [-o suspicious-processes.csv]\p"
     const example_vt_domain_lookup = "  vt-domain-lookup  -a <API-KEY> --domainList domains.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
     const example_vt_hash_lookup = "  vt-hash-lookup -a <API-KEY> --hashList case-1-MD5-hashes.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
@@ -56,7 +58,7 @@ when isMainModule:
     clCfg.useMulti = "Version: 2.1.0 Halloween Release\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
         examples & example_extract_scriptblocks & example_list_domains & example_list_hashes & example_list_ip_addresses & example_list_undetected_evtx & example_list_unused_rules &
         example_split_csv_timeline & example_split_json_timeline & example_stack_logons & example_sysmon_process_tree &
-        example_timeline_logon & example_timeline_suspicious_processes &
+        example_timeline_logon & example_timeline_partition_diagnostic & example_timeline_suspicious_processes &
         example_vt_domain_lookup & example_vt_hash_lookup & example_vt_ip_lookup
 
     if paramCount() == 0:
@@ -188,6 +190,15 @@ when isMainModule:
             short = {
                 "outputLogoffEvents": 'l',
                 "outputAdminLogonEvents": 'a'
+            }
+        ],
+        [
+            timelinePartitionDiagnostic, cmdName = "timeline-partition-diagnostic",
+            doc = "create a CSV timeline of partition diagnostic events",
+            help = {
+                "output": "save results to a CSV file",
+                "quiet": "do not display the launch banner",
+                "timeline": "Hayabusa JSONL timeline (profile: any)",
             }
         ],
         [

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -157,7 +157,7 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
             path = jsonLine["ExtraFieldInfo"].getOrDefault("Path").getStr()
             if path == "":
                 path = "no-path"
-        except:
+        except CatchableError:
             continue
 
         if scriptBlockId in stackedRecords:

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -92,7 +92,7 @@ proc getHayabusaCsvData*(csvPath: string, columnName: string): Tableref[string, 
     try:
         open(p, s, csvPath)
         p.readHeaderRow()
-    except:
+    except CatchableError:
         quit("Failed to open '" & csvPath & "' because it is not in CSV format.\nPlease specify a CSV that has been created with the Hayabusa csv-timeline command.")
     let r = newTable[string, seq[string]]()
     # initialize table

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -46,10 +46,10 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
 
     bar.finish()
 
+    let header = ["Timestamp", "Computer", "Manufacturer", "Model", "Revision", "SerialNumber"]
     if output != "":
         # Open file to save results
         var outputFile = open(output, fmWrite)
-        let header = ["Timestamp", "Computer", "Manufacturer", "Model", "Revision", "SerialNumber"]
 
         ## Write CSV header
         outputFile.write(header.join(",") & "\p")
@@ -66,6 +66,14 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
         let fileSize = getFileSize(output)
         echo ""
         echo "Saved results to " & output & " (" & formatFileSize(fileSize) & ")"
+        echo ""
+    else:
+        echo ""
+        var table: TerminalTable
+        table.add header
+        for t in seqOfResultsTables:
+            table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]]
+        table.echoTableSeps(seps = boxSeps)
         echo ""
 
     let endTime = epochTime()

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -7,7 +7,7 @@ proc changeByteOrder(vsnStr:string): string =
 
 proc extractVSN(jsonLine: JsonNode) : array[4, string] =
     var res:array[4, string] = ["n/a", "n/a", "n/a", "n/a"]
-    if jsonLine["ExtraFieldInfo"]["PartitionStyle"].getInt() != 0:
+    if "PartitionStyle" notin jsonLine["ExtraFieldInfo"] or jsonLine["ExtraFieldInfo"]["PartitionStyle"].getInt() != 0:
         return res
     for i, vbrNo in ["Vbr0", "Vbr1", "Vbr2", "Vbr3"]:
         if vbrNo notin jsonLine["ExtraFieldInfo"]:

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -56,9 +56,12 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
 
         ## Write contents
         for table in seqOfResultsTables:
-            for key in header:
+            for i, key in enumerate(header):
                 if table.hasKey(key):
-                    outputFile.write(escapeCsvField(table[key]) & ",")
+                    if i < header.len() - 1:
+                        outputFile.write(escapeCsvField(table[key]) & ",")
+                    else:
+                        outputFile.write(escapeCsvField(table[key]))
                 else:
                     outputFile.write(",")
             outputFile.write("\p")

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -1,3 +1,34 @@
+proc changeByteOrder(vsnStr:string): string =
+    var res: seq[string]
+    for i, ch in vsnStr:
+        if i mod 2 != 0:
+            res.add(vsnStr[i - 1] & vsnStr[i])
+    return join(res.reversed, "")
+
+proc extractVSN(jsonLine: JsonNode) : array[4, string] =
+    var res:array[4, string] = ["n/a", "n/a", "n/a", "n/a"]
+    if jsonLine["ExtraFieldInfo"]["PartitionStyle"].getInt() != 0:
+        return res
+    for i, vbrNo in ["Vbr0", "Vbr1", "Vbr2", "Vbr3"]:
+        if vbrNo notin jsonLine["ExtraFieldInfo"]:
+            continue
+        let vbr = jsonLine["ExtraFieldInfo"][vbrNo].getStr()
+        if vbr.len < 18:
+            res[i] = ""
+            continue
+        let sig = vbr[6..17]
+        var vsnLittleEndian = ""
+        if sig == "4D53444F5335" and jsonLine["ExtraFieldInfo"][vbrNo].getStr().len > 141: # FAT32
+            vsnLittleEndian = jsonLine["ExtraFieldInfo"][vbrNo].getStr()[134..141]
+        elif sig == "455846415420" and jsonLine["ExtraFieldInfo"][vbrNo].getStr().len > 207: #ExFAT
+            vsnLittleEndian = jsonLine["ExtraFieldInfo"][vbrNo].getStr()[200..207]
+        elif sig == "4E5446532020" and jsonLine["ExtraFieldInfo"][vbrNo].getStr().len > 151: # NTFS
+            vsnLittleEndian = jsonLine["ExtraFieldInfo"][vbrNo].getStr()[144..151]
+        if vsnLittleEndian != "":
+            res[i] = changeByteOrder(vsnLittleEndian)
+    return res
+
+
 proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timeline: string) =
     let startTime = epochTime()
     if not quiet:
@@ -42,11 +73,15 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
         singleResultTable["Model"] = jsonLine["Details"]["Model"].getStr()
         singleResultTable["Revision"] = jsonLine["Details"]["Revision"].getStr()
         singleResultTable["SerialNumber"] = jsonLine["Details"]["SerialNumber"].getStr()
+        for i, vsn in extractVSN(jsonLine):
+            var val = "n/a"
+            if vsn != "":
+                val = vsn
+            singleResultTable["VSN" & intToStr(i)] = val
         seqOfResultsTables.add(singleResultTable)
-
     bar.finish()
 
-    let header = ["Timestamp", "Computer", "Manufacturer", "Model", "Revision", "SerialNumber"]
+    let header = ["Timestamp", "Computer", "Manufacturer", "Model", "Revision", "SerialNumber", "VSN0", "VSN1", "VSN2", "VSN3"]
     if output != "":
         # Open file to save results
         var outputFile = open(output, fmWrite)
@@ -75,7 +110,7 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
         var table: TerminalTable
         table.add header
         for t in seqOfResultsTables:
-            table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]]
+            table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]], t[header[6]], t[header[7]], t[header[8]], t[header[9]]
         table.echoTableSeps(seps = boxSeps)
         echo ""
 

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -1,0 +1,78 @@
+proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timeline: string) =
+    let startTime = epochTime()
+    if not quiet:
+        styledEcho(fgGreen, outputLogo())
+
+    if not os.fileExists(timeline):
+        echo "The file '" & timeline & "' does not exist. Please specify a valid file path."
+        quit(1)
+
+    if not isJsonConvertible(timeline):
+        quit(1)
+
+    echo "Started the Timeline partition diagnostic command"
+    echo "This command will create a CSV timeline of partition diagnostic."
+    echo ""
+
+    echo "Counting total lines. Please wait."
+    echo ""
+    let totalLines = countLinesInTimeline(timeline)
+    echo "Total lines: ", totalLines
+    echo ""
+
+    var
+        jsonLine: JsonNode
+        bar: SuruBar = initSuruBar()
+        seqOfResultsTables: seq[Table[string, string]]
+
+    bar[0].total = totalLines
+    bar.setup()
+
+    for line in lines(timeline):
+        inc bar
+        bar.update(1000000000) # refresh every second
+        jsonLine = parseJson(line)
+
+        if jsonLine["EventID"].getInt() != 1006 or jsonLine["Channel"].getStr() != "MS-Win-Partition/Diagnostic":
+            continue
+        var singleResultTable = initTable[string, string]()
+        singleResultTable["Timestamp"] = jsonLine["Timestamp"].getStr()
+        singleResultTable["Computer"] = jsonLine["Computer"].getStr()
+        singleResultTable["Manufacturer"] = jsonLine["Details"]["Manufacturer"].getStr()
+        singleResultTable["Model"] = jsonLine["Details"]["Model"].getStr()
+        singleResultTable["Revision"] = jsonLine["Details"]["Revision"].getStr()
+        singleResultTable["SerialNumber"] = jsonLine["Details"]["SerialNumber"].getStr()
+        seqOfResultsTables.add(singleResultTable)
+
+    bar.finish()
+
+    if output != "":
+        # Open file to save results
+        var outputFile = open(output, fmWrite)
+        let header = ["Timestamp", "Computer", "Manufacturer", "Model", "Revision", "SerialNumber"]
+
+        ## Write CSV header
+        outputFile.write(header.join(",") & "\p")
+
+        ## Write contents
+        for table in seqOfResultsTables:
+            for key in header:
+                if table.hasKey(key):
+                    outputFile.write(escapeCsvField(table[key]) & ",")
+                else:
+                    outputFile.write(",")
+            outputFile.write("\p")
+        outputFile.close()
+        let fileSize = getFileSize(output)
+        echo ""
+        echo "Saved results to " & output & " (" & formatFileSize(fileSize) & ")"
+        echo ""
+
+    let endTime = epochTime()
+    let elapsedTime = int(endTime - startTime)
+    let hours = elapsedTime div 3600
+    let minutes = (elapsedTime mod 3600) div 60
+    let seconds = elapsedTime mod 60
+
+    echo "Elapsed time: ", $hours & " hours, " & $minutes & " minutes, " & $seconds & " seconds"
+    echo ""


### PR DESCRIPTION
## What Changed
- feat: #67
  -  extract `EventID` == `1006` and `Channel` == `MS-Win-Partition/Diagnostic`
  - output following field
    - `Timestamp`
    - `Computer`
    - `Manufacturer` 
    - `Model`
    - `Revision` 
    - `SerialNumber`
- related: https://github.com/Yamato-Security/hayabusa-rules/pull/534

## Test

### Environment
- OS: macOS Sonoma version 14.0
- Hayabusa v2.10.1
- Nim: 2.0.0

### Test
without -o option
<img width="1440" alt="スクリーンショット 2023-11-19 8 30 49" src="https://github.com/Yamato-Security/takajo/assets/41001169/4de2c4b9-6f97-4557-8a00-4606282cb74e">


with -o option
<img width="1440" alt="スクリーンショット 2023-11-19 8 43 31" src="https://github.com/Yamato-Security/takajo/assets/41001169/b4c85983-5185-4caa-8852-dbb44ff37122">

I would appreciate it if you could review when you have time🙏