### PR TITLE
fix: modify mojibake in stdout `timeline-partition-diagnostic`

### DIFF
--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -44,42 +44,6 @@ proc buildSummaryRecord(path: string, messageTotal: int,
     let maxLevel = calcMaxAlert(scriptObj.levels)
     return [ts, cs, id, path, records, maxLevel, ruleTitles]
 
-proc colorWrite(color: ForegroundColor, ansiEscape: string, txt: string) =
-    # Remove ANSI escape sequences and use stdout.styledWrite instead
-    let replacedTxt = txt.replace(ansiEscape,"").replace(termClear,"")
-    if "│" in replacedTxt:
-      stdout.styledWrite(color, replacedTxt.replace("│ ",""))
-      stdout.write "│ "
-    else:
-      stdout.styledWrite(color, replacedTxt)
-
-proc stdoutStyledWrite(txt: string) =
-    if txt.startsWith(termRed):
-      colorWrite(fgRed, termRed,txt)
-    elif txt.startsWith(termGreen):
-      colorWrite(fgGreen, termGreen, txt)
-    elif txt.startsWith(termYellow):
-      colorWrite(fgYellow, termYellow, txt)
-    elif txt.startsWith(termCyan):
-      colorWrite(fgCyan, termCyan, txt)
-    else:
-      stdout.write txt.replace(termClear,"")
-
-proc echoTableSepsWithStyled(table: TerminalTable, maxSize = terminalWidth(), seps = defaultSeps) =
-    # This function equivalent to echoTableSeps without using ANSI escape to avoid the following issue.
-    # https://github.com/PMunch/nancy/issues/4
-    # https://github.com/PMunch/nancy/blob/9918716a563f64d740df6a02db42662781e94fc8/src/nancy.nim#L195C6-L195C19
-    let sizes = table.getColumnSizes(maxSize - 4, padding = 3)
-    printSeparator(top)
-    for k, entry in table.entries(sizes):
-      for _, row in entry():
-        stdout.write seps.vertical & " "
-        for i, cell in row():
-          stdoutStyledWrite cell & (if i != sizes.high: " " & seps.vertical & " " else: "")
-        stdout.write " " & seps.vertical & "\n"
-      if k != table.rows - 1:
-        printSeparator(center)
-    printSeparator(bottom)
 
 proc extractScriptblocks(level: string = "low", output: string = "scriptblock-logs",
         quiet: bool = false, timeline: string) =

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -1,4 +1,7 @@
 import json
+import nancy
+import terminal
+import termstyle
 import re
 import std/os
 import std/parsecsv
@@ -340,6 +343,43 @@ proc isJsonConvertible*(timeline: string) : bool =
       close(file)
   echo "Failed to open '" & timeline & "'. Please specify a valid file path.\p"
   return false
+
+proc colorWrite*(color: ForegroundColor, ansiEscape: string, txt: string) =
+    # Remove ANSI escape sequences and use stdout.styledWrite instead
+    let replacedTxt = txt.replace(ansiEscape,"").replace(termClear,"")
+    if "│" in replacedTxt:
+      stdout.styledWrite(color, replacedTxt.replace("│ ",""))
+      stdout.write "│ "
+    else:
+      stdout.styledWrite(color, replacedTxt)
+
+proc stdoutStyledWrite*(txt: string) =
+    if txt.startsWith(termRed):
+      colorWrite(fgRed, termRed,txt)
+    elif txt.startsWith(termGreen):
+      colorWrite(fgGreen, termGreen, txt)
+    elif txt.startsWith(termYellow):
+      colorWrite(fgYellow, termYellow, txt)
+    elif txt.startsWith(termCyan):
+      colorWrite(fgCyan, termCyan, txt)
+    else:
+      stdout.write txt.replace(termClear,"")
+
+proc echoTableSepsWithStyled*(table: TerminalTable, maxSize = terminalWidth(), seps = defaultSeps) =
+    # This function equivalent to echoTableSeps without using ANSI escape to avoid the following issue.
+    # https://github.com/PMunch/nancy/issues/4
+    # https://github.com/PMunch/nancy/blob/9918716a563f64d740df6a02db42662781e94fc8/src/nancy.nim#L195C6-L195C19
+    let sizes = table.getColumnSizes(maxSize - 4, padding = 3)
+    printSeparator(top)
+    for k, entry in table.entries(sizes):
+      for _, row in entry():
+        stdout.write seps.vertical & " "
+        for i, cell in row():
+          stdoutStyledWrite cell & (if i != sizes.high: " " & seps.vertical & " " else: "")
+        stdout.write " " & seps.vertical & "\n"
+      if k != table.rows - 1:
+        printSeparator(center)
+    printSeparator(bottom)
 
 type VirusTotalResult* = object
   resTable*: TableRef[string, string]

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -111,7 +111,7 @@ proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timel
         table.add header
         for t in seqOfResultsTables:
             table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]], t[header[6]], t[header[7]], t[header[8]], t[header[9]]
-        table.echoTableSeps(seps = boxSeps)
+        table.echoTableSepsWithStyled(seps = boxSeps)
         echo ""
 
     let endTime = epochTime()


### PR DESCRIPTION
## What Changed
- fixed: #74 

## Test

### Environment
- OS: Windows11
- Hayabusa v2.11.0
- Nim: 2.0.0


### timeline-partition-diagnostic
![fixed](https://github.com/Yamato-Security/takajo/assets/41001169/9457150e-f269-4c5f-a554-b757d4063feb)


### exstract-scriptblocks
![fix2](https://github.com/Yamato-Security/takajo/assets/41001169/1079dcfb-9c27-4274-979a-6c3a9d0ccd70)


I would appreciate it if you could review when you have time🙏

