### PR TITLE
feat: add `RuleTitle` to`mitre-attack-navigator.json`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## 2.x.x [xxxx/xx/xx]
+
+**Enhancements:**
+
+- In the `ttp-visualize` command, the name of the rule that detected the technique will now be shown in the comment when hovering over the technique in MITRE ATT&CK Navigator. (#82) (@fukusuket)
+
 ## 2.3.0 [2023/12/23] - SECCON Christmas Release
 
 **新機能:**

--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,9 +2,9 @@
 
 ## 2.x.x [xxxx/xx/xx]
 
-**Enhancements:**
+**改善:**
 
-- In the `ttp-visualize` command, the name of the rule that detected the technique will now be shown in the comment when hovering over the technique in MITRE ATT&CK Navigator. (#82) (@fukusuket)
+- `ttp-visualize` コマンドで、MITRE ATT&CK Navigator上のテクニックをマウスオーバーしたときに、検知ルール名が表示されるようした。(#82) (@fukusuket)
 
 ## 2.3.0 [2023/12/23] - SECCON Christmas Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.x.x [xxxx/xx/xx]
+
+**Enhancements:**
+
+- In the `ttp-visualize` command, the name of the rule that detected the technique will now be shown in the comment when hovering over the technique in MITRE ATT&CK Navigator. (#82) (@fukusuket)
+
 ## 2.3.0 [2023/12/23] - SECCON Christmas Release
 
 **New Features:**

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -32,7 +32,7 @@ proc ttpVisualize(output: string = "mitre-attack-navigator.json", quiet: bool = 
         let jsonLine = parseJson(line)
         try:
             for tag in jsonLine["MitreTags"]:
-              stackedMitreTags.add({"techniqueID":  tag.getStr(), "color": "#fd8d3c"}.newTable)
+              stackedMitreTags.add({"techniqueID":  tag.getStr(), "color": "#fd8d3c", "comment": jsonLine["RuleTitle"].getStr()}.newTable)
         except CatchableError:
             continue
 


### PR DESCRIPTION
## What Changed
- related: #76
- added `RuleTile` to comment field.
   - It would be better for the user to be able to check on ATT&CK Navigator **which rule the techniqueID was detected by**.
example:
```json
{
  "name": "Hayabusa detection result heatmap",
  "versions": {
    "attack": "14",
    "navigator": "4.9.1",
    "layer": "4.5"
  },
  "domain": "enterprise-attack",
  "description": "Hayabusa detection result heatmap",
  "techniques": [
    {
      "color": "#fd8d3c",
      "techniqueID": "T1070.006",
      "comment": "Unauthorized System Time Modification"
    },
    {
      "color": "#fd8d3c",
      "techniqueID": "T1098",
      "comment": "A Member Was Added to a Security-Enabled Global Group"
    }
   ]
}
```

## Test

### Environment
- OS: macOS Sonoma version 14.0
- Hayabusa v2.12.0
- Nim: 2.0.0

### Test
#### hayabusa-sample-evtx's result
```
./takajo ttp-visualize -t timeline.jsonl
...
Started the TTP Visualize command.
This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.

Counting total lines. Please wait.
Total lines: 32317

100%|█████████████████████████| 32317/32317 [ 0.8s< 0.0s,  45.92k/sec]

Saved file: mitre-attack-navigator.json (1.50 MB)

Elapsed time: 0 hours, 0 minutes, 0 seconds
```
<img width="1440" alt="スクリーンショット 2023-12-27 23 25 32" src="https://github.com/Yamato-Security/takajo/assets/41001169/c550562b-ece3-4967-b977-27f982036d6b">

I would appreciate it if you could check it out when you have time🙏

