### PR TITLE
feat: add color gradient to ttp-visualize

### DIFF
--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -1,6 +1,7 @@
 import algorithm
 import cligen
 import json
+import math
 import nancy
 import puppy
 import re

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -2,18 +2,11 @@ type
   TTPResult = object
     techniqueID: string
     comment: string
-    color: string
     score: int
 
 proc newTTPResult(techniqueID: string, comment: string, score: int): TTPResult =
   result.techniqueID = techniqueID
   result.comment = comment
-  if score < toInt(100 / 3):
-    result.color = "#8ec843ff"
-  elif score < toInt((100 / 3) * 2):
-    result.color = "#ffe766ff"
-  else:
-    result.color = "#ff6666ff"
   result.score = score
 
 proc ttpVisualize(output: string = "mitre-attack-navigator.json", quiet: bool = false, timeline: string) =
@@ -82,7 +75,24 @@ proc ttpVisualize(output: string = "mitre-attack-navigator.json", quiet: bool = 
                             },
                             "domain": "enterprise-attack",
                             "description": "Hayabusa detection result heatmap",
-                            "techniques": mitreTags
+                            "techniques": mitreTags,
+                            "gradient": {
+                                "colors": [
+                                  "#8ec843ff",
+                                  "#ffe766ff",
+                                  "#ff6666ff"
+                                ],
+                              "minValue": 0,
+                              "maxValue": 100
+                              },
+                              "legendItems": [],
+                              "metadata": [],
+                              "links": [],
+                              "showTacticRowBackground": false,
+                              "tacticRowBackground": "#dddddd",
+                              "selectTechniquesAcrossTactics": true,
+                              "selectSubtechniquesWithParent": false,
+                              "selectVisibleTechniques": false
                         }
 
         let outputFile = open(output, FileMode.fmWrite)

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -8,14 +8,12 @@ type
 proc newTTPResult(techniqueID: string, comment: string, score: int): TTPResult =
   result.techniqueID = techniqueID
   result.comment = comment
-  if score == 1:
-    result.color = "#fca2a2"
-  elif score == 2 :
-    result.color = "#fc6b6b"
-  elif score == 3 :
-    result.color = "#fc3b3b"
+  if score < toInt(100 / 3):
+    result.color = "#8ec843ff"
+  elif score < toInt((100 / 3) * 2):
+    result.color = "#ffe766ff"
   else:
-    result.color = "#e60d0d"
+    result.color = "#ff6666ff"
   result.score = score
 
 proc ttpVisualize(output: string = "mitre-attack-navigator.json", quiet: bool = false, timeline: string) =
@@ -71,8 +69,10 @@ proc ttpVisualize(output: string = "mitre-attack-navigator.json", quiet: bool = 
         echo "Please run your Hayabusa scan with a profile that includes the %MitreTags% field. (ex: -p verbose)"
     else:
         var mitreTags = newSeq[TTPResult]()
+        let maxCount = stackedMitreTagsCount.values.toSeq.max
         for techniqueID, ruleTitle in stackedMitreTags:
-            mitreTags.add(newTTPResult(techniqueID, ruleTitle, stackedMitreTagsCount[techniqueID]))
+            let score = toInt(round(stackedMitreTagsCount[techniqueID]/maxCount * 100))
+            mitreTags.add(newTTPResult(techniqueID, ruleTitle, score))
         let jsonObj = %* {
                             "name": "Hayabusa detection result heatmap",
                             "versions": {


### PR DESCRIPTION
## What Changed
- feat: #90 

### Color gradient
I use the following four red colors.
<img width="743" alt="スクリーンショット 2024-02-04 14 47 14" src="https://github.com/Yamato-Security/takajo/assets/41001169/507f19f8-1fc7-4758-b89d-ac0424963428">

The color-coding logic is simply divided into four categories based on score( = number of detections).
```Nim
  if score == 1:
    result.color = "#fca2a2"
  elif score == 2 :
    result.color = "#fc6b6b"
  elif score == 3 :
    result.color = "#fc3b3b"
  else:
    result.color = "#e60d0d"
```

### hayabusa-sample-evtx
<img width="1440" alt="スクリーンショット 2024-02-04 14 50 21" src="https://github.com/Yamato-Security/takajo/assets/41001169/d4fe4c77-de74-4f85-8654-8123bfa9cc6b">

### baseline evtx v8
<img width="1440" alt="スクリーンショット 2024-02-04 15 24 25" src="https://github.com/Yamato-Security/takajo/assets/41001169/897b4497-1587-4d7a-b711-ba2c0357f82b">

### apt29 day2
<img width="1440" alt="スクリーンショット 2024-02-04 15 28 51" src="https://github.com/Yamato-Security/takajo/assets/41001169/13841e7c-02da-4b8f-80b7-ddc9b031fcc7">

