### PR TITLE
chg: update GitHub Actions libraries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Nim
         uses: jiro4989/setup-nim-action@v1
@@ -71,9 +71,9 @@ jobs:
           mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: release-binaries
+          name: release-binaries-${{ matrix.os }}
           path: |
             release-binaries/*.zip
             ./*.pdf


### PR DESCRIPTION
## What Changed
- Fixed: #89  

## Test
https://github.com/Yamato-Security/takajo/actions/runs/7852542825
<img width="1000" alt="スクリーンショット 2024-02-10 13 32 33" src="https://github.com/Yamato-Security/takajo/assets/41001169/80e613ab-4495-4e47-90bb-cd1ac3a02fa4">


<img width="400" alt="スクリーンショット 2024-02-10 13 31 09" src="https://github.com/Yamato-Security/takajo/assets/41001169/a44df90f-d2d6-425c-91c9-f79df2fc74a7">

## Restrictions
Unfortunately...Since it is no longer possible to upload multiple jobs to a single artifact using the upload-artifact action, artifacts are separated by OS.

https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
