### PR TITLE
fix: calculate computer column number each execution

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -10,6 +10,10 @@
 
 - `ttp-visualize`コマンド: ヒートマップにカラーグラデーションを追加した。 (#90) (@fukusuket)
 
+**バグ修正:**
+
+- `split-csv-timeline`コマンドが、Haybuasa 2.13.0のCSV結果で失敗するので、修正した。(#103) (@fukusuket)
+
 ## 2.3.1 [2024/01/27] - Year Of The Dragon Release
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `ttp-visualize` command: added color gradient to the heatmap. (#90) (@fukusuket)
 
+**Bug Fixes:**
+
+- `split-csv-timeline` command failed with Haybuasa 2.13.0 CSV results. (#103) (@fukusuket)
+
 ## 2.3.1 [2024/01/27] - Year Of The Dragon Release
 
 **Enhancements:**

--- a/src/takajopkg/splitCsvTimeline.nim
+++ b/src/takajopkg/splitCsvTimeline.nim
@@ -34,10 +34,22 @@ proc splitCsvTimeline(makeMultiline: bool = false, output: string = "output", qu
         bar: SuruBar = initSuruBar()
 
     bar[0].total = totalLines
-    bar.setup()
 
     # Read in the CSV header
     let csvHeader = inputFile.readLine()
+    let headerColums = csvHeader.split(',')
+    var computerColumnNum = 0
+    for i, col in enumerate(headerColums):
+        if "Computer" in col:
+            computerColumnNum = i
+            break
+    if computerColumnNum == 0:
+        echo ""
+        echo "There is no column for Computer. Please specify a valid csv."
+        createDir(output)
+    echo ""
+    bar.setup()
+
     inc bar
     while inputFile.endOfFile == false:
         inc bar
@@ -45,7 +57,7 @@ proc splitCsvTimeline(makeMultiline: bool = false, output: string = "output", qu
 
         var currentLine = inputFile.readLine()
         let splitFields = currentLine.split(',')
-        var computerName = splitFields[1]
+        var computerName = splitFields[computerColumnNum]
         computerName = computerName[1 .. computerName.len - 2] # Remove surrounding double quotes
 
         # If it is the first time we see this computer name, then record it in a str sequence, create a file,


### PR DESCRIPTION
## What Changed
- Closed: #103

## Test

### Environment
- OS: macOS Sonoma version 14.2.1
- Hayabusa v2.12.0/v2.13.0
- Nim: 2.0.2
- nimble: 0.14.2

### Hayabusa 2.12.0
```
fukusuke@fukusukenoMacBook-Air hayabusa-2.12.0-mac % ./takajo split-csv-timeline -t timeline.csv -q
Started the Split CSV Timeline command

This command will split a large CSV timeline into many multiple ones based on computer name.
If you want to separate the field data by newlines, add the -m option.

Counting total lines. Please wait.

Total lines: 32373

Splitting the Hayabusa CSV timeline. Please wait.


100%|█████████████████████████| 32373/32373 [ 0.3s< 0.0s, 192.24k/sec]

Saved file: output/37L4247D28-05-HayabusaResults.csv (33.40 KB)
Saved file: output/IE8Win7-HayabusaResults.csv (82.02 KB)
Saved file: output/IE9Win7-HayabusaResults.csv (9.91 KB)
Saved file: output/IE10Win7-HayabusaResults.csv (4.83 MB)
Saved file: output/DESKTOP-M5SN04R-HayabusaResults.csv (3.35 MB)
Saved file: output/--HayabusaResults.csv (1.15 KB)
Saved file: output/2016dc.hqcorp.local-HayabusaResults.csv (397 Bytes)
Saved file: output/2012r2srv.maincorp.local-HayabusaResults.csv (2.02 KB)
Saved file: output/SEC511-HayabusaResults.csv (3.26 MB)
Saved file: output/IEWIN7-HayabusaResults.csv (1.13 MB)
...
Elapsed time: 0 hours, 0 minutes, 0 seconds
```

### Hayabusa 2.13.0
```
./takajo split-csv-timeline -t timeline.csv -q
Started the Split CSV Timeline command

This command will split a large CSV timeline into many multiple ones based on computer name.
If you want to separate the field data by newlines, add the -m option.

Counting total lines. Please wait.

Total lines: 32373

Splitting the Hayabusa CSV timeline. Please wait.


100%|█████████████████████████| 32373/32373 [ 0.2s< 0.0s, 192.58k/sec]

Saved file: output/37L4247D28-05-HayabusaResults.csv (33.40 KB)
Saved file: output/IE8Win7-HayabusaResults.csv (82.02 KB)
Saved file: output/IE9Win7-HayabusaResults.csv (9.91 KB)
Saved file: output/IE10Win7-HayabusaResults.csv (4.83 MB)
Saved file: output/DESKTOP-M5SN04R-HayabusaResults.csv (3.35 MB)
Saved file: output/--HayabusaResults.csv (1.15 KB)
Saved file: output/2016dc.hqcorp.local-HayabusaResults.csv (397 Bytes)
Saved file: output/2012r2srv.maincorp.local-HayabusaResults.csv (2.02 KB)
Saved file: output/SEC511-HayabusaResults.csv (3.26 MB)
Saved file: output/IEWIN7-HayabusaResults.csv (1.13 MB)
...
Elapsed time: 0 hours, 0 minutes, 0 seconds
```

I would appreciate it if you could check it out when you have time🙏