### PR TITLE
refactor: apply Template method pattern for automagic command

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: run extract-scriptblocks
         run: cd takajo && ./takajo extract-scriptblocks -t timeline.jsonl
 
+      - name: run extract-scriptblocks(-s)
+        run: cd takajo && ./takajo extract-scriptblocks -t timeline.jsonl -s
+
       - name: run extract-scriptblocks(-o)
         run: cd takajo && ./takajo extract-scriptblocks -t timeline.jsonl -o scriptblocks
 
@@ -68,11 +71,20 @@ jobs:
       - name: run list-domain(-s)
         run: cd takajo && ./takajo list-domains -t timeline.jsonl -o domains.txt -s
 
+      - name: run list-domain(-d/-w)
+        run: cd takajo && ./takajo list-domains -t timeline.jsonl -o domains.txt -d -w
+
       - name: run list-hashes(-o)
         run: cd takajo && ./takajo list-hashes -t timeline.jsonl -o case-1
 
+      - name: run list-hashes(-s)
+        run: cd takajo && ./takajo list-hashes -t timeline.jsonl -o case-1 -s
+
       - name: run list-ip-addresses(-o)
         run: cd takajo && ./takajo list-ip-addresses -t timeline.jsonl -o ipAddresses.txt
+
+      - name: run list-ip-addresses(-s)
+        run: cd takajo && ./takajo list-ip-addresses -t timeline.jsonl -o ipAddresses.txt -s
 
       - name: run list-ip-addresses(-i)
         run: cd takajo && ./takajo list-ip-addresses -t timeline.jsonl -o ipAddresses.txt -i=false
@@ -107,11 +119,17 @@ jobs:
       - name: run stack-computers(-s)
         run: cd takajo && ./takajo stack-computers -t timeline.jsonl -o computers.csv -s
 
+      - name: run stack-computers(-c)
+        run: cd takajo && ./takajo stack-computers -t timeline.jsonl -o computers.csv -c
+
       - name: run stack-cmdlines
         run: cd takajo && ./takajo stack-cmdlines -t timeline.jsonl
 
       - name: run stack-cmdlines(-o)
         run: cd takajo && ./takajo stack-cmdlines -t timeline.jsonl -o cmdlines.csv
+
+      - name: run stack-cmdlines(-s)
+        run: cd takajo && ./takajo stack-cmdlines -t timeline.jsonl -o cmdlines.csv -s
 
       - name: run stack-cmdlines(-l)
         run: cd takajo && ./takajo stack-cmdlines -t timeline.jsonl -o cmdlines.csv -l informational
@@ -122,6 +140,9 @@ jobs:
       - name: run stack-dns(-o)
         run: cd takajo && ./takajo stack-dns -t timeline.jsonl -o dns.csv
 
+      - name: run stack-dns(-s)
+        run: cd takajo && ./takajo stack-dns -t timeline.jsonl -o dns.csv -s
+
       - name: run stack-ip-addresses
         run: cd takajo && ./takajo stack-ip-addresses -t timeline.jsonl
 
@@ -130,6 +151,9 @@ jobs:
 
       - name: run stack-ip-addresses(-a)
         run: cd takajo && ./takajo stack-ip-addresses -t timeline.jsonl -o ipAddresses.csv -a
+
+      - name: run stack-ip-addresses(-s)
+        run: cd takajo && ./takajo stack-ip-addresses -t timeline.jsonl -o ipAddresses.csv -s
 
       - name: run stack-logons
         run: cd takajo && ./takajo stack-logons -t timeline.jsonl
@@ -140,11 +164,17 @@ jobs:
       - name: run stack-logons(-o)
         run: cd takajo && ./takajo stack-logons -t timeline.jsonl -o logon.csv
 
+      - name: run stack-logons(-s)
+        run: cd takajo && ./takajo stack-logons -t timeline.jsonl -o logon.csv -s
+
       - name: run stack-processes
         run: cd takajo && ./takajo stack-processes -t timeline.jsonl
 
       - name: run stack-processes(-o)
         run: cd takajo && ./takajo stack-processes -t timeline.jsonl -o processes.csv
+
+      - name: run stack-processes(-s)
+        run: cd takajo && ./takajo stack-processes -t timeline.jsonl -o processes.csv -s
 
       - name: run stack-processes(-l)
         run: cd takajo && ./takajo stack-processes -t timeline.jsonl -o processes.csv -l informational
@@ -155,11 +185,17 @@ jobs:
       - name: run stack-services(-o)
         run: cd takajo && ./takajo stack-services -t timeline.jsonl -o services.csv
 
+      - name: run stack-services(-s)
+        run: cd takajo && ./takajo stack-services -t timeline.jsonl -o services.csv -s
+
       - name: run stack-tasks
         run: cd takajo && ./takajo stack-tasks -t timeline.jsonl
 
       - name: run stack-tasks(-o)
         run: cd takajo && ./takajo stack-tasks -t timeline.jsonl -o tasks.csv
+
+      - name: run stack-tasks(-s)
+        run: cd takajo && ./takajo stack-tasks -t timeline.jsonl -o tasks.csv -s
 
       - name: run stack-users
         run: cd takajo && ./takajo stack-users -t timeline.jsonl
@@ -169,6 +205,9 @@ jobs:
 
       - name: run stack-users(-s)
         run: cd takajo && ./takajo stack-users -t timeline.jsonl -o users.csv -s
+
+      - name: run stack-users(-c)
+        run: cd takajo && ./takajo stack-users -t timeline.jsonl -o users.csv -c
 
       - name: run sysmon-process-tree
         run: cd takajo && ./takajo sysmon-process-tree -t timeline.jsonl -p "365ABB72-3D4A-5CEB-0000-0010FA93FD00" -o process-tree.txt
@@ -185,20 +224,38 @@ jobs:
       - name: run timeline-logon(-a)
         run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -a -o logon-timeline.csv
 
+      - name: run timeline-logon(-s)
+        run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -s -o logon-timeline.csv
+
       - name: run timeline-partition-diagnostic
         run: cd takajo && ./takajo timeline-partition-diagnostic -t timeline.jsonl -o partition-diagnostic-timeline.csv
+
+      - name: run timeline-partition-diagnostic(-s)
+        run: cd takajo && ./takajo timeline-partition-diagnostic -t timeline.jsonl -o partition-diagnostic-timeline.csv -s
 
       - name: run timeline-suspicious-process
         run: cd takajo && ./takajo timeline-suspicious-process -t timeline.jsonl -o suspicous-processes.csv
 
+      - name: run timeline-suspicious-process(-s)
+        run: cd takajo && ./takajo timeline-suspicious-process -t timeline.jsonl -o suspicous-processes.csv -s
+
       - name: run timeline-tasks
         run: cd takajo && ./takajo timeline-tasks -t timeline.jsonl -o task-timeline.csv
+
+      - name: run timeline-tasks(-s)
+        run: cd takajo && ./takajo timeline-tasks -t timeline.jsonl -o task-timeline.csv -s
 
       - name: run ttp-summary
         run: cd takajo && ./takajo ttp-summary -t timeline.jsonl -o ttp-summary.csv
 
+      - name: run ttp-summary(-s)
+        run: cd takajo && ./takajo ttp-summary -t timeline.jsonl -o ttp-summary.csv -s
+
       - name: run ttp-visualize
         run: cd takajo && ./takajo ttp-visualize -t timeline.jsonl
+
+      - name: run ttp-visualize(-s)
+        run: cd takajo && ./takajo ttp-visualize -t timeline.jsonl -s
 
       - name: run ttp-visualize-sigma
         run: cd takajo && ./takajo ttp-visualize-sigma -r ../hayabusa/tmp/rules

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -176,6 +176,15 @@ jobs:
       - name: run timeline-logon
         run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -o logon-timeline.csv
 
+      - name: run timeline-logon(-c)
+        run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -c -o logon-timeline.csv
+
+      - name: run timeline-logon(-l)
+        run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -l -o logon-timeline.csv
+
+      - name: run timeline-logon(-a)
+        run: cd takajo && ./takajo timeline-logon -t timeline.jsonl -a -o logon-timeline.csv
+
       - name: run timeline-partition-diagnostic
         run: cd takajo && ./takajo timeline-partition-diagnostic -t timeline.jsonl -o partition-diagnostic-timeline.csv
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -60,7 +60,8 @@ include takajopkg/automagic
 when isMainModule:
     clCfg.version = "2.5.0-dev"
     const examples = "Examples:\p"
-    const example_automagic = "  automagic -t ../hayabusa/timeline.jsonl [--level low] -o case-1\p"
+    # TODO automagicコマンドのプロトタイプ
+    # const example_automagic = "  automagic -t ../hayabusa/timeline.jsonl [--level low] -o case-1\p"
     const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low] -o scriptblock-logs\p"
     const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o domains.txt\p"
     const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl [--skipProgressBar] -o case-1\p"
@@ -91,7 +92,10 @@ when isMainModule:
     const example_vt_ip_lookup = "  vt-ip-lookup -a <API-KEY> --ipList ipAddresses.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
 
     clCfg.useMulti = "Version: 2.5.0 Dev Build\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
-        examples & example_automagic & example_extract_scriptblocks &
+        examples &
+        # TODO automagicコマンドのプロトタイプ
+        # example_automagic &
+        example_extract_scriptblocks &
         example_list_domains & example_list_hashes & example_list_ip_addresses & example_list_undetected_evtx & example_list_unused_rules &
         example_split_csv_timeline & example_split_json_timeline &
         example_stack_cmdlines & example_stack_computers & example_stack_dns & example_stack_ip_addresses & example_stack_logons & example_stack_processes & example_stack_services & example_stack_tasks & example_stack_users &
@@ -103,17 +107,18 @@ when isMainModule:
     if paramCount() == 0:
         styledEcho(fgGreen, outputLogo())
     dispatchMulti(
-        [
-            autoMagic, cmdName = "automagic",
-            doc = "automatically executes as many commands as possible and output results to a new folder",
-            help = {
-                "level": "specify the minimum alert level (default: low)",
-                "skipProgressBar": "do not display the progress bar",
-                "output": "output directory (default: scriptblock-logs)",
-                "quiet": "do not display the launch banner",
-                "timeline": "Hayabusa JSONL timeline (profile: any)",
-            }
-        ],
+        # TODO automagicコマンドのプロトタイプ
+        # [
+        #     autoMagic, cmdName = "automagic",
+        #     doc = "automatically executes as many commands as possible and output results to a new folder",
+        #     help = {
+        #         "level": "specify the minimum alert level (default: low)",
+        #         "skipProgressBar": "do not display the progress bar",
+        #         "output": "output directory (default: scriptblock-logs)",
+        #         "quiet": "do not display the launch banner",
+        #         "timeline": "Hayabusa JSONL timeline (profile: any)",
+        #     }
+        # ],
         [
             extractScriptblocks, cmdName = "extract-scriptblocks",
             doc = "extract and reassemble PowerShell EID 4104 script block logs",

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -21,7 +21,7 @@ import std/xmlparser
 import std/xmltree
 import takajopkg/general
 import takajopkg/hayabusaJson
-import takajopkg/stackUtil
+import takajopkg/stackCommon
 import takajopkg/takajoCore
 import takajopkg/takajoTerminal
 import takajopkg/ttpResult

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -54,11 +54,13 @@ include takajopkg/ttpVisualizeSigma
 include takajopkg/vtDomainLookup
 include takajopkg/vtIpLookup
 include takajopkg/vtHashLookup
+include takajopkg/automagic
 
 
 when isMainModule:
     clCfg.version = "2.5.0-dev"
     const examples = "Examples:\p"
+    const example_automagic = "  automagic -t ../hayabusa/timeline.jsonl [--level low] -o case-1\p"
     const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low] -o scriptblock-logs\p"
     const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o domains.txt\p"
     const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl [--skipProgressBar] -o case-1\p"
@@ -89,7 +91,7 @@ when isMainModule:
     const example_vt_ip_lookup = "  vt-ip-lookup -a <API-KEY> --ipList ipAddresses.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
 
     clCfg.useMulti = "Version: 2.5.0 Dev Build\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
-        examples & example_extract_scriptblocks &
+        examples & example_automagic & example_extract_scriptblocks &
         example_list_domains & example_list_hashes & example_list_ip_addresses & example_list_undetected_evtx & example_list_unused_rules &
         example_split_csv_timeline & example_split_json_timeline &
         example_stack_cmdlines & example_stack_computers & example_stack_dns & example_stack_ip_addresses & example_stack_logons & example_stack_processes & example_stack_services & example_stack_tasks & example_stack_users &
@@ -101,6 +103,17 @@ when isMainModule:
     if paramCount() == 0:
         styledEcho(fgGreen, outputLogo())
     dispatchMulti(
+        [
+            autoMagic, cmdName = "automagic",
+            doc = "automatically executes as many commands as possible and output results to a new folder",
+            help = {
+                "level": "specify the minimum alert level (default: low)",
+                "skipProgressBar": "do not display the progress bar",
+                "output": "output directory (default: scriptblock-logs)",
+                "quiet": "do not display the launch banner",
+                "timeline": "Hayabusa JSONL timeline (profile: any)",
+            }
+        ],
         [
             extractScriptblocks, cmdName = "extract-scriptblocks",
             doc = "extract and reassemble PowerShell EID 4104 script block logs",

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -22,6 +22,7 @@ import std/xmltree
 import takajopkg/general
 import takajopkg/hayabusaJson
 import takajopkg/stackUtil
+import takajopkg/takajoCore
 import takajopkg/takajoTerminal
 import takajopkg/ttpResult
 import takajopkg/vtResult

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -60,30 +60,30 @@ when isMainModule:
     clCfg.version = "2.5.0-dev"
     const examples = "Examples:\p"
     const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low] -o scriptblock-logs\p"
-    const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl -o domains.txt\p"
-    const example_list_ip_addresses = "  list-ip-addresses -t ../hayabusa/timeline.jsonl -o ipAddresses.txt\p"
+    const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o domains.txt\p"
+    const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl [--skipProgressBar] -o case-1\p"
+    const example_list_ip_addresses = "  list-ip-addresses -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o ipAddresses.txt\p"
     const example_list_undetected_evtx = "  list-undetected-evtx -t ../hayabusa/timeline.csv -e ../hayabusa-sample-evtx\p"
     const example_list_unused_rules = "  list-unused-rules -t ../hayabusa/timeline.csv -r ../hayabusa/rules\p"
     const example_split_csv_timeline = "  split-csv-timeline -t ../hayabusa/timeline.csv [--makeMultiline] -o case-1-csv\p"
     const example_split_json_timeline = "  split-json-timeline -t ../hayabusa/timeline.jsonl -o case-1-json\p"
-    const example_stack_cmdlines = "  stack-cmdlines -t ../hayabusa/timeline.jsonl [--level low] -o cmdlines.csv\p"
-    const example_stack_computers = "  stack-computers -t ../hayabusa/timeline.jsonl [--level informational] [--sourceComputers] -o computers.csv\p"
-    const example_stack_dns = "  stack-dns -t ../hayabusa/timeline.jsonl [--level infomational]  -o dns.csv\p"
-    const example_stack_ip_addresses = "  stack-ip-addresses -t ../hayabusa/timeline.jsonl [--level infomational] [--targetIpAddresses] -o ipAddresses.csv\p"
-    const example_stack_logons = "  stack-logons -t ../hayabusa/timeline.jsonl -o logons.csv\p"
-    const example_stack_processes = "  stack-processes -t ../hayabusa/timeline.jsonl [--level low] -o processes.csv\p"
-    const example_stack_services  = "  stack-services -t ../hayabusa/timeline.jsonl [--level infomational] -o services.csv\p"
-    const example_stack_tasks = "  stack-tasks -t ../hayabusa/timeline.jsonl [--level infomational] -o tasks.csv\p"
-    const example_stack_users = "  stack-users -t ../hayabusa/timeline.jsonl [--level infomational] [--sourceUsers] [--filterSystemAccounts] [--filterComputerAccounts] -o users.csv\p"
-    const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl -o case-1\p"
+    const example_stack_cmdlines = "  stack-cmdlines -t ../hayabusa/timeline.jsonl [--level low] [--skipProgressBar] -o cmdlines.csv\p"
+    const example_stack_computers = "  stack-computers -t ../hayabusa/timeline.jsonl [--level informational] [--sourceComputers] [--skipProgressBar] -o computers.csv\p"
+    const example_stack_dns = "  stack-dns -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o dns.csv\p"
+    const example_stack_ip_addresses = "  stack-ip-addresses -t ../hayabusa/timeline.jsonl [--level infomational] [--targetIpAddresses] [--skipProgressBar] -o ipAddresses.csv\p"
+    const example_stack_logons = "  stack-logons -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o logons.csv\p"
+    const example_stack_processes = "  stack-processes -t ../hayabusa/timeline.jsonl [--level low] [--skipProgressBar] -o processes.csv\p"
+    const example_stack_services  = "  stack-services -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o services.csv\p"
+    const example_stack_tasks = "  stack-tasks -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o tasks.csv\p"
+    const example_stack_users = "  stack-users -t ../hayabusa/timeline.jsonl [--level infomational] [--sourceUsers] [--filterSystemAccounts] [--filterComputerAccounts] [--skipProgressBar] -o users.csv\p"
     const example_sysmon_process_tree = "  sysmon-process-tree -t ../hayabusa/timeline.jsonl -p <Process GUID> [-o process-tree.txt]\p"
-    const example_timeline_logon = "  timeline-logon -t ../hayabusa/timeline.jsonl -o logon-timeline.csv\p"
-    const example_timeline_partition_diagnostic = "  timeline-partition-diagnostic -t ../hayabusa/timeline.jsonl -o partition-diagnostic-timeline.csv\p"
-    const example_timeline_suspicious_processes = "  timeline-suspicious-processes -t ../hayabusa/timeline.jsonl [--level medium] [-o suspicious-processes.csv]\p"
-    const example_timeline_tasks = "  timeline-tasks -t ../hayabusa/timeline.jsonl -o task-timeline.csv\p"
+    const example_timeline_logon = "  timeline-logon -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o logon-timeline.csv\p"
+    const example_timeline_partition_diagnostic = "  timeline-partition-diagnostic -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o partition-diagnostic-timeline.csv\p"
+    const example_timeline_suspicious_processes = "  timeline-suspicious-processes -t ../hayabusa/timeline.jsonl [--level medium] [--skipProgressBar] [-o suspicious-processes.csv]\p"
+    const example_timeline_tasks = "  timeline-tasks -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o task-timeline.csv\p"
     const example_vt_domain_lookup = "  vt-domain-lookup  -a <API-KEY> --domainList domains.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
-    const example_ttp_summary = "  ttp-summary -t ../hayabusa/timeline.jsonl -o ttp-summary.csv\p"
-    const example_ttp_visualize = "  ttp-visualize -t ../hayabusa/timeline.jsonl -o mitre-ttp-heatmap.json\p"
+    const example_ttp_summary = "  ttp-summary -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o ttp-summary.csv\p"
+    const example_ttp_visualize = "  ttp-visualize -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o mitre-ttp-heatmap.json\p"
     const example_ttp_visualize_sigma = "  ttp-visualize-sigma -r ../hayabusa/rules -o sigma-rules-heatmap.json\p"
     const example_vt_hash_lookup = "  vt-hash-lookup -a <API-KEY> --hashList case-1-MD5-hashes.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
     const example_vt_ip_lookup = "  vt-ip-lookup -a <API-KEY> --ipList ipAddresses.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
@@ -106,6 +106,7 @@ when isMainModule:
             doc = "extract and reassemble PowerShell EID 4104 script block logs",
             help = {
                 "level": "specify the minimum alert level (default: low)",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "output directory (default: scriptblock-logs)",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any)",
@@ -117,12 +118,13 @@ when isMainModule:
             help = {
                 "includeSubdomains": "include subdomains",
                 "includeWorkstations": "include local workstation names",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a text file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
             },
             short = {
-                "includeSubdomains": 's',
+                "includeSubdomains": 'd',
                 "includeWorkstations": 'w'
             }
         ],
@@ -131,6 +133,7 @@ when isMainModule:
             doc = "create a list of process hashes to be used with vt-hash-lookup",
             help = {
                 "level": "specify the minimum alert level",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "specify the base name to save results to text files (ex: -o case-1)",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -142,6 +145,7 @@ when isMainModule:
             help = {
                 "inbound": "include inbound traffic",
                 "outbound": "include outbound traffic",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a text file",
                 "privateIp": "include private IP addresses",
                 "quiet": "do not display the launch banner",
@@ -199,9 +203,13 @@ when isMainModule:
             help = {
                 "level": "specify the minimum alert level (default: low)",
                 "sourceComputers" : "stack source computers instead of target computers",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
+            },
+            short = {
+                "sourceComputers": 'c'
             }
         ],
         [
@@ -211,6 +219,7 @@ when isMainModule:
                 "level": "specify the minimum alert level (default: low)",
                 "ignoreSysmon": "exclude Sysmon 1 events",
                 "ignoreSecurity": "exclude Security 4688 events",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -225,6 +234,7 @@ when isMainModule:
             doc = "stack DNS queries and responses",
             help = {
                 "level": "specify the minimum alert level (default: informational)",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -236,6 +246,7 @@ when isMainModule:
             help = {
                 "level": "specify the minimum alert level (default: informational)",
                 "targetIpAddresses" : "stack target IP addresses instead of source IP addresses",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any)",
@@ -249,6 +260,7 @@ when isMainModule:
             doc = "stack logons by target user, target computer, source IP address and source computer",
             help = {
                 "localSrcIpAddresses": "include results when the source IP address is local",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -261,6 +273,7 @@ when isMainModule:
                 "level": "specify the minimum alert level (default: low)",
                 "ignoreSysmon": "exclude Sysmon 1 events",
                 "ignoreSecurity": "exclude Security 4688 events",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -275,6 +288,7 @@ when isMainModule:
             doc = "stack service names and paths",
             help = {
                 "level": "specify the minimum alert level (default: informational)",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -289,6 +303,7 @@ when isMainModule:
             doc = "stack new scheduled tasks",
             help = {
                 "level": "specify the minimum alert level (default: informational)",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -302,6 +317,7 @@ when isMainModule:
                 "sourceUsers" : "stack source users instead of target users (default: false)",
                 "filterComputerAccounts": "filter out computer accounts (default: true)",
                 "filterSystemAccounts": "filter out system accounts (default: true)",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any)",
@@ -329,6 +345,7 @@ when isMainModule:
                 "output": "save results to a CSV file",
                 "outputAdminLogonEvents": "output admin logon events as separate entries",
                 "outputLogoffEvents": "output logoff events as separate entries",
+                "skipProgressBar": "do not display the progress bar",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
             },
@@ -341,6 +358,7 @@ when isMainModule:
             timelinePartitionDiagnostic, cmdName = "timeline-partition-diagnostic",
             doc = "create a CSV timeline of partition diagnostic events",
             help = {
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any)",
@@ -351,6 +369,7 @@ when isMainModule:
             doc = "create a CSV timeline of suspicious processes",
             help = {
                 "level": "specify the minimum alert level",
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any besides all-field-info*)",
@@ -360,6 +379,7 @@ when isMainModule:
             timelineTasks, cmdName = "timeline-tasks",
             doc = "create a CSV timeline of scheduled tasks",
             help = {
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a CSV file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any)",
@@ -369,6 +389,7 @@ when isMainModule:
             ttpSummary, cmdName = "ttp-summary",
             doc = "summarize tactics and techniques found in each computer",
             help = {
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a csv file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any verbose profile)",
@@ -378,6 +399,7 @@ when isMainModule:
             ttpVisualize, cmdName = "ttp-visualize",
             doc = "extract TTPs and create a JSON file to visualize in MITRE ATT&CK Navigator",
             help = {
+                "skipProgressBar": "do not display the progress bar",
                 "output": "save results to a json file",
                 "quiet": "do not display the launch banner",
                 "timeline": "Hayabusa JSONL timeline (profile: any verbose profile)",

--- a/src/takajopkg/automagic.nim
+++ b/src/takajopkg/automagic.nim
@@ -17,6 +17,8 @@ proc autoMagic(level: string = "low", skipProgressBar:bool = false, output: stri
 
     # extract-scriptblocks -t ../hayabusa/timeline.jsonl -l <level> -o case-1/scriptblock-logs/
     let cmd1 = ExtractScriptBlocksCmd(level: level, skipProgressBar: skipProgressBar, timeline: timeline, output: output & "/scriptblock-logs/")
+    if not dirExists(output & "/scriptblock-logs/"):
+        createDir(output & "/scriptblock-logs/")
 
     # list-domains -t ../hayabusa/timeline.jsonl -o case-1/ListDomains.txt
     let cmd2 = ListDomainsCmd(timeline: timeline, output: output & "/ListDomains.txt")

--- a/src/takajopkg/automagic.nim
+++ b/src/takajopkg/automagic.nim
@@ -1,6 +1,6 @@
 const AutoMagicMsg =
   """
-  Automatically executes as many commands as possible and output results to a new folder!
+Automatically executes as many commands as possible and output results to a new folder!
   """
 
 type

--- a/src/takajopkg/automagic.nim
+++ b/src/takajopkg/automagic.nim
@@ -33,28 +33,28 @@ proc autoMagic(level: string = "low", skipProgressBar:bool = false, output: stri
     let cmd5 = ListIpAddressesCmd(timeline:timeline, output:output & "/IP-Addresses.txt")
 
     # stack-cmdlines -t ../hayabusa/timeline.jsonl --level <leve> -o case-1/cmdlines.csv
-    let cmd6 = StackCmdlineCmd(level:level, timeline:timeline, output:output & "/cmdlines.csv")
+    let cmd6 = StackCmdlineCmd(name:"Cmdlines", level:level, timeline:timeline, output:output & "/cmdlines.csv")
 
     # stack-computers -t ../hayabusa/timeline.jsonl --level <level> -o case-1/TargetComputers.csv
-    let cmd7 = StackComputersCmd(level:level, timeline:timeline, output:output & "/TargetComputers.csv")
+    let cmd7 = StackComputersCmd(name: "Computers", level:level, timeline:timeline, output:output & "/TargetComputers.csv")
 
     # stack-computers -t ../hayabusa/timeline.jsonl --level <level> --sourceComputers -o case-1/SourceComputers.csv
-    let cmd8 = StackComputersCmd(level:level, timeline:timeline, output:output & "/SourceComputers.csv", sourceComputers:true)
+    let cmd8 = StackComputersCmd(name: "Computers", level:level, timeline:timeline, output:output & "/SourceComputers.csv", sourceComputers:true)
 
     # stack-dns -t ../hayabusa/timeline.jsonl --level <level>  -o case-1/DNS.csv
     let cmd9 = StackDNSCmd(level:level, timeline:timeline, output:output & "/DNS.csv")
 
     # stack-ip-addresses -t ../hayabusa/timeline.jsonl --level <level> -o case-1/SourceIP-Addresses.csv
-    let cmd10 = StackIpAddressesCmd(level:level, timeline:timeline, output:output & "/SourceIP-Addresses.csv")
+    let cmd10 = StackIpAddressesCmd(name: "IpAddresses", level:level, timeline:timeline, output:output & "/SourceIP-Addresses.csv")
 
     # stack-ip-addresses -t ../hayabusa/timeline.jsonl --level <level> --targetIpAddresses -o case-1/TargetIP-Addresses.csv
-    let cmd11 = StackIpAddressesCmd(level:level, timeline:timeline, output:output & "/TargetIP-Addresses.csv", targetIpAddresses:true)
+    let cmd11 = StackIpAddressesCmd(name: "IpAddresses", level:level, timeline:timeline, output:output & "/TargetIP-Addresses.csv", targetIpAddresses:true)
 
     # stack-logons -t ../hayabusa/timeline.jsonl -o case-1/Logons.csv
     let cmd12 = StackLogonsCmd(timeline:timeline, output:output & "/Logons.csv")
 
     # stack-processes -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Processes.csv
-    let cmd13 = StackProcessesCmd(level:level, timeline:timeline, output:output & "/Processes.csv")
+    let cmd13 = StackProcessesCmd(name: "Processes", level:level, timeline:timeline, output:output & "/Processes.csv")
 
     # stack-services -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Services.csv
     let cmd14 = StackServicesCmd(level:level, timeline:timeline, output:output & "/Services.csv")
@@ -63,16 +63,16 @@ proc autoMagic(level: string = "low", skipProgressBar:bool = false, output: stri
     let cmd15 = StackTasksCmd(level:level, timeline:timeline, output:output & "/Tasks.csv")
 
     # stack-users -t ../hayabusa/timeline.jsonl --level <level> -o case-1/TargetUsers.csv
-    let cmd16 = StackUsersCmd(level:level, timeline:timeline, output:output & "/TargetUsers.csv")
+    let cmd16 = StackUsersCmd(name:"Users", level:level, timeline:timeline, output:output & "/TargetUsers.csv")
 
     # stack-users -t ../hayabusa/timeline.jsonl --level <level> --filterSystemAccounts=false --filterComputerAccounts=false -o case-1/TargetUsers-NoFiltering.csv
-    let cmd17 = StackUsersCmd(level:level, timeline:timeline, output:output & "/TargetUsers-NoFiltering.csv")
+    let cmd17 = StackUsersCmd(name:"Users", level:level, timeline:timeline, output:output & "/TargetUsers-NoFiltering.csv")
 
     # stack-users -t ../hayabusa/timeline.jsonl --level <level> --sourceUsers -o users.csv
-    let cmd18 = StackUsersCmd(level:level, timeline:timeline, output:output & "/users.csv", sourceUsers:true)
+    let cmd18 = StackUsersCmd(name:"Users", level:level, timeline:timeline, output:output & "/users.csv", sourceUsers:true)
 
     # stack-users -t ../hayabusa/timeline.jsonl --level <level> --sourceUsers --filterSystemAccounts=false --filterComputerAccounts=false -o case-1/SourceUsers-NoFiltering.csv
-    let cmd19 = StackUsersCmd(level:level, timeline:timeline, output:output & "/SourceUsers-NoFiltering.csv", sourceUsers:true, filterSystemAccounts:false, filterComputerAccounts:false)
+    let cmd19 = StackUsersCmd(name:"Users", level:level, timeline:timeline, output:output & "/SourceUsers-NoFiltering.csv", sourceUsers:true, filterSystemAccounts:false, filterComputerAccounts:false)
 
     # timeline-logon -t ../hayabusa/timeline.jsonl -o case-1/LogonTimeline.csv
     let cmd20 = TimelineLogonCmd(timeline:timeline, output:output & "/LogonTimeline.csv")

--- a/src/takajopkg/automagic.nim
+++ b/src/takajopkg/automagic.nim
@@ -1,0 +1,97 @@
+const AutoMagicMsg =
+  """
+  Automatically executes as many commands as possible and output results to a new folder!
+  """
+
+type
+  AutoMagicCmd* = ref object of AbstractCmd
+      level: string
+
+proc autoMagic(level: string = "low", skipProgressBar:bool = false, output: string = "case-1", quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, level)
+    if dirExists(output):
+        echo "The directory '" & output & "' exists. Please specify a new folder name."
+        quit(1)
+    else:
+        createDir(output)
+
+    # extract-scriptblocks -t ../hayabusa/timeline.jsonl -l <level> -o case-1/scriptblock-logs/
+    let cmd1 = ExtractScriptBlocksCmd(level: level, skipProgressBar: skipProgressBar, timeline: timeline, output: output & "/scriptblock-logs/")
+
+    # list-domains -t ../hayabusa/timeline.jsonl -o case-1/ListDomains.txt
+    let cmd2 = ListDomainsCmd(timeline: timeline, output: output & "/ListDomains.txt")
+
+    # list-domains -t ../hayabusa/timeline.jsonl -d -w -o case-1/ListDomains-Detailed.txt
+    let cmd3 = ListDomainsCmd(timeline:timeline, output:output & "/ListDomains-Detailed.txt", includeSubdomains:true, includeWorkstations:true)
+
+    # list-hashes -t ../hayabusa/timeline.jsonl -l <level> -o case-1/hashes
+    let cmd4 = ListHashesCmd(timeline:timeline, level:level, output:output & "/hashes")
+
+    # list-ip-addresses -t ../hayabusa/timeline.jsonl -o case-1/IP-Addresses.txt
+    let cmd5 = ListIpAddressesCmd(timeline:timeline, output:output & "/IP-Addresses.txt")
+
+    # stack-cmdlines -t ../hayabusa/timeline.jsonl --level <leve> -o case-1/cmdlines.csv
+    let cmd6 = StackCmdlineCmd(level:level, timeline:timeline, output:output & "/cmdlines.csv")
+
+    # stack-computers -t ../hayabusa/timeline.jsonl --level <level> -o case-1/TargetComputers.csv
+    let cmd7 = StackComputersCmd(level:level, timeline:timeline, output:output & "/TargetComputers.csv")
+
+    # stack-computers -t ../hayabusa/timeline.jsonl --level <level> --sourceComputers -o case-1/SourceComputers.csv
+    let cmd8 = StackComputersCmd(level:level, timeline:timeline, output:output & "/SourceComputers.csv", sourceComputers:true)
+
+    # stack-dns -t ../hayabusa/timeline.jsonl --level <level>  -o case-1/DNS.csv
+    let cmd9 = StackDNSCmd(level:level, timeline:timeline, output:output & "/DNS.csv")
+
+    # stack-ip-addresses -t ../hayabusa/timeline.jsonl --level <level> -o case-1/SourceIP-Addresses.csv
+    let cmd10 = StackIpAddressesCmd(level:level, timeline:timeline, output:output & "/SourceIP-Addresses.csv")
+
+    # stack-ip-addresses -t ../hayabusa/timeline.jsonl --level <level> --targetIpAddresses -o case-1/TargetIP-Addresses.csv
+    let cmd11 = StackIpAddressesCmd(level:level, timeline:timeline, output:output & "/TargetIP-Addresses.csv", targetIpAddresses:true)
+
+    # stack-logons -t ../hayabusa/timeline.jsonl -o case-1/Logons.csv
+    let cmd12 = StackLogonsCmd(timeline:timeline, output:output & "/Logons.csv")
+
+    # stack-processes -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Processes.csv
+    let cmd13 = StackProcessesCmd(level:level, timeline:timeline, output:output & "/Processes.csv")
+
+    # stack-services -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Services.csv
+    let cmd14 = StackServicesCmd(level:level, timeline:timeline, output:output & "/Services.csv")
+
+    # stack-tasks -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Tasks.csv
+    let cmd15 = StackTasksCmd(level:level, timeline:timeline, output:output & "/Tasks.csv")
+
+    # stack-users -t ../hayabusa/timeline.jsonl --level <level> -o case-1/TargetUsers.csv
+    let cmd16 = StackUsersCmd(level:level, timeline:timeline, output:output & "/TargetUsers.csv")
+
+    # stack-users -t ../hayabusa/timeline.jsonl --level <level> --filterSystemAccounts=false --filterComputerAccounts=false -o case-1/TargetUsers-NoFiltering.csv
+    let cmd17 = StackUsersCmd(level:level, timeline:timeline, output:output & "/TargetUsers-NoFiltering.csv")
+
+    # stack-users -t ../hayabusa/timeline.jsonl --level <level> --sourceUsers -o users.csv
+    let cmd18 = StackUsersCmd(level:level, timeline:timeline, output:output & "/users.csv", sourceUsers:true)
+
+    # stack-users -t ../hayabusa/timeline.jsonl --level <level> --sourceUsers --filterSystemAccounts=false --filterComputerAccounts=false -o case-1/SourceUsers-NoFiltering.csv
+    let cmd19 = StackUsersCmd(level:level, timeline:timeline, output:output & "/SourceUsers-NoFiltering.csv", sourceUsers:true, filterSystemAccounts:false, filterComputerAccounts:false)
+
+    # timeline-logon -t ../hayabusa/timeline.jsonl -o case-1/LogonTimeline.csv
+    let cmd20 = TimelineLogonCmd(timeline:timeline, output:output & "/LogonTimeline.csv")
+
+    # timeline-partition-diagnostic -t ../hayabusa/timeline.jsonl -o case-1/PartitionDiagnosticTimeline.csv
+    let cmd21 = TimelinePartitionDiagnosticCmd(timeline:timeline, output:output & "/PartitionDiagnosticTimeline.csv")
+
+    # timeline-suspicious-processes -t ../hayabusa/timeline.jsonl --level <level> -o case-1/SuspiciousProcesses.csv
+    let cmd22 = TimelineSuspiciousProcessesCmd(level:level, timeline:timeline, output:output & "/SuspiciousProcesses.csv")
+
+    # timeline-tasks -t ../hayabusa/timeline.jsonl -o case-1/TaskTimeline.csv
+    let cmd23 = TimelineTasksCmd(timeline:timeline, output:output & "/TaskTimeline.csv")
+
+    # ttp-summary -t ../hayabusa/timeline.jsonl -o case-1/TTP-Summary.csv
+    let cmd24 = TTPSummaryCmd(timeline:timeline, output:output & "/TTP-Summary.csv")
+    cmd24.attack = readJsonFromFile("mitre-attack.json")
+
+    # ttp-visualize -t ../hayabusa/timeline.jsonl -o case-1/MitreTTP-Heatmap.json
+    let cmd25 = TTPVisualizeCmd(timeline:timeline, output:output & "/MitreTTP-Heatmap.json")
+
+    # execute all command
+    let cmds = @[cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8, cmd9, cmd10, cmd11, cmd12, cmd13, cmd14, cmd15, cmd16, cmd17, cmd18, cmd19, cmd20, cmd21, cmd22, cmd23, cmd24, cmd25]
+    let baseCmd = AutoMagicCmd(level: level, skipProgressBar:skipProgressBar, output: output, timeline: timeline, name:"automagic",  msg:AutoMagicMsg)
+    analyzeJSONLFileWithMultipleCmd(baseCmd, cmds)

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -138,6 +138,7 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
     let cmd = ExtractScriptBlocksCmd(
                 timeline: timeline,
                 output: output,
+                level: level,
                 name:"Extract ScriptBlock",
                 msg: ExtractScriptBlocksMsg)
     cmd.totalLines = countLinesInTimeline(timeline, true)

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -75,29 +75,27 @@ method analyze*(self: ExtractScriptBlocksCmd, x: HayabusaJson) =
             path = jsonLine.ExtraFieldInfo.getOrDefault("Path").getStr()
         if path == "":
             path = "no-path"
-        var stackedRecords = self.stackedRecords
-        var summaryRecords = self.summaryRecords
-        if scriptBlockId in stackedRecords:
-            stackedRecords[scriptBlockId].levels.incl(eventLevel)
-            stackedRecords[scriptBlockId].ruleTitles.incl(ruleTitle)
-            stackedRecords[scriptBlockId].scriptBlocks.incl(scriptBlock)
+        if scriptBlockId in self.stackedRecords:
+            self.stackedRecords[scriptBlockId].levels.incl(eventLevel)
+            self.stackedRecords[scriptBlockId].ruleTitles.incl(ruleTitle)
+            self.stackedRecords[scriptBlockId].scriptBlocks.incl(scriptBlock)
         else:
-            stackedRecords[scriptBlockId] = Script(firstTimestamp: timestamp,
+            self.stackedRecords[scriptBlockId] = Script(firstTimestamp: timestamp,
                     computerName: computerName,
                     scriptBlockId: scriptBlockId,
                     scriptBlocks: toOrderedSet([scriptBlock]),
                     levels:toHashSet([eventLevel]), ruleTitles:toHashSet([ruleTitle]))
-        let scriptObj = stackedRecords[scriptBlockId]
+        let scriptObj = self.stackedRecords[scriptBlockId]
         if messageNumber == messageTotal:
-            if scriptBlockId in summaryRecords:
-                summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
+            if scriptBlockId in self.summaryRecords:
+                self.summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
                 # Already outputted
                 discard
             outputScriptText(self.output, timestamp, computerName, scriptObj)
-            summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
+            self.summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
         elif self.currentIndex + 1 == self.totalLines:
             outputScriptText(self.output, timestamp, computerName, scriptObj)
-            summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
+            self.summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
     except CatchableError:
         discard
 

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -1,8 +1,4 @@
-const ExtractScriptBlocksMsg =
-  """
-  Started the Extract Scriptblock command.
-  This command will extract PowerShell Script Block.
-  """
+const ExtractScriptBlocksMsg = "This command will extract PowerShell Script Block."
 
 type Script = ref object
     firstTimestamp: string

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -129,16 +129,17 @@ method resultOutput*(self: ExtractScriptBlocksCmd) =
         echo "Saved summary file: " & summaryFile & " (" & formatFileSize(outputFileSize) & ")"
 
 
-proc extractScriptblocks(level: string = "low", output: string = "scriptblock-logs", quiet: bool = false, timeline: string) =
+proc extractScriptblocks(level: string = "low", skipProgressBar:bool = false, output: string = "scriptblock-logs", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     if not dirExists(output):
         echo "The directory '" & output & "' does not exist so will be created."
         createDir(output)
         echo ""
     let cmd = ExtractScriptBlocksCmd(
+                level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                level: level,
                 name:"Extract ScriptBlock",
                 msg: ExtractScriptBlocksMsg)
     cmd.totalLines = countLinesInTimeline(timeline, true)

--- a/src/takajopkg/extractScriptblocks.nim
+++ b/src/takajopkg/extractScriptblocks.nim
@@ -1,3 +1,9 @@
+const ExtractScriptBlocksMsg =
+  """
+  Started the Extract Scriptblock command.
+  This command will extract PowerShell Script Block.
+  """
+
 type Script = ref object
     firstTimestamp: string
     computerName: string
@@ -17,7 +23,6 @@ proc outputScriptText(output: string, timestamp: string, computerName: string,
     outputFile.write(scriptText)
     flushFile(outputFile)
     close(outputFile)
-
 
 proc calcMaxAlert(levels:HashSet):string =
     if "crit" in levels:
@@ -43,59 +48,22 @@ proc buildSummaryRecord(path: string, messageTotal: int,
     let maxLevel = calcMaxAlert(scriptObj.levels)
     return [ts, cs, id, path, records, maxLevel, ruleTitles]
 
+type
+  ExtractScriptBlocksCmd* = ref object of AbstractCmd
+      currentIndex*  = 0
+      totalLines* = 0
+      stackedRecords* = newTable[string, Script]()
+      summaryRecords* = newOrderedTable[string, array[7, string]]()
+      level*: string
 
-proc extractScriptblocks(level: string = "low", output: string = "scriptblock-logs",
-        quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, level)
+method filter*(self: ExtractScriptBlocksCmd, x: HayabusaJson):bool =
+    inc self.currentIndex
+    return x.EventID == 4104 and isMinLevel(x.Level, self.level)
 
-    echo "Started the Extract ScriptBlock command."
-    echo "This command will extract PowerShell Script Block."
-    echo ""
-
-    let totalLines = countLinesInTimeline(timeline)
-
-    if level == "critical":
-        echo "Extracting PowerShell ScriptBlocks with an alert level of critical. Please wait."
-    else:
-        echo "Extracting PowerShell ScriptBlocks with a minimal alert level of " & level & ". Please wait."
-    echo ""
-
-    if not dirExists(output):
-        echo "The directory '" & output & "' does not exist so will be created."
-        createDir(output)
-        echo ""
-
-    var
-        bar: SuruBar = initSuruBar()
-        currentIndex  = 0
-        stackedRecords = newTable[string, Script]()
-        summaryRecords = newOrderedTable[string, array[7, string]]()
-        timestamp: string
-        computerName: string
-        eventLevel: string
-        ruleTitle: string
-        scriptBlock: string
-        scriptBlockId: string
-        messageNumber: int
-        messageTotal: int
-        path: string
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc currentIndex
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-
-        if jsonLine.EventID != 4104 or isMinLevel(jsonLine.Level, level) == false:
-            continue
-        try:
+method analyze*(self: ExtractScriptBlocksCmd, x: HayabusaJson) =
+    let jsonLine = x
+    try:
+        var
             timestamp = jsonLine.Timestamp
             computerName = jsonLine.Computer
             eventLevel = jsonLine.Level
@@ -105,11 +73,10 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
             messageNumber = jsonLine.ExtraFieldInfo["MessageNumber"].getInt()
             messageTotal = jsonLine.ExtraFieldInfo["MessageTotal"].getInt()
             path = jsonLine.ExtraFieldInfo.getOrDefault("Path").getStr()
-            if path == "":
-                path = "no-path"
-        except CatchableError:
-            continue
-
+        if path == "":
+            path = "no-path"
+        var stackedRecords = self.stackedRecords
+        var summaryRecords = self.summaryRecords
         if scriptBlockId in stackedRecords:
             stackedRecords[scriptBlockId].levels.incl(eventLevel)
             stackedRecords[scriptBlockId].ruleTitles.incl(ruleTitle)
@@ -120,26 +87,25 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
                     scriptBlockId: scriptBlockId,
                     scriptBlocks: toOrderedSet([scriptBlock]),
                     levels:toHashSet([eventLevel]), ruleTitles:toHashSet([ruleTitle]))
-
         let scriptObj = stackedRecords[scriptBlockId]
         if messageNumber == messageTotal:
             if scriptBlockId in summaryRecords:
                 summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
                 # Already outputted
-                continue
-            outputScriptText(output, timestamp, computerName, scriptObj)
+                discard
+            outputScriptText(self.output, timestamp, computerName, scriptObj)
             summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
-        elif currentIndex + 1 == totalLines:
-            outputScriptText(output, timestamp, computerName, scriptObj)
+        elif self.currentIndex + 1 == self.totalLines:
+            outputScriptText(self.output, timestamp, computerName, scriptObj)
             summaryRecords[scriptBlockId] = buildSummaryRecord(path, messageTotal, scriptObj)
+    except CatchableError:
+        discard
 
-    bar.finish()
-    echo ""
-
-    if summaryRecords.len == 0:
+method resultOutput*(self: ExtractScriptBlocksCmd) =
+    if self.summaryRecords.len == 0:
         echo "No malicious powershell script block were found. There are either no malicious powershell script block or you need to change the level."
     else:
-        let summaryFile = output & "/" & "summary.csv"
+        let summaryFile = self.output & "/" & "summary.csv"
         let header = ["Creation Time", "Computer Name", "Script ID", "Script Name", "Records", "Level", "Alerts"]
         var outputFile = open(summaryFile, fmWrite)
         var table: TerminalTable
@@ -149,7 +115,7 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
                 outputFile.write(escapeCsvField(val) & ",")
             else:
                 outputFile.write(escapeCsvField(val) & "\p")
-        for v in summaryRecords.values:
+        for v in self.summaryRecords.values:
             let color = levelColor(v[5])
             table.add color v[0], color v[1], color v[2], color v[3], color v[4], color v[5], color v[6]
             for i, cell in v:
@@ -161,6 +127,20 @@ proc extractScriptblocks(level: string = "low", output: string = "scriptblock-lo
         outputFile.close()
         table.echoTableSepsWithStyled(seps = boxSeps)
         echo ""
-        echo "The extracted PowerShell ScriptBlock is saved in the directory: " & output
+        echo "The extracted PowerShell ScriptBlock is saved in the directory: " & self.output
         echo "Saved summary file: " & summaryFile & " (" & formatFileSize(outputFileSize) & ")"
-    outputElapsedTime(startTime)
+
+
+proc extractScriptblocks(level: string = "low", output: string = "scriptblock-logs", quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, level)
+    if not dirExists(output):
+        echo "The directory '" & output & "' does not exist so will be created."
+        createDir(output)
+        echo ""
+    let cmd = ExtractScriptBlocksCmd(
+                timeline: timeline,
+                output: output,
+                name:"Extract ScriptBlock",
+                msg: ExtractScriptBlocksMsg)
+    cmd.totalLines = countLinesInTimeline(timeline, true)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -367,7 +367,7 @@ proc checkArgs*(quiet: bool = false, timeline: string, level:string) =
 proc countJsonlAndStartMsg*(cmdName:string, msg:string, timeline:string):int =
     echo "Started the " & cmdName & " command"
     echo ""
-    echo "This command will stack " &  msg & "."
+    echo msg
     echo ""
 
     let totalLines = countLinesInTimeline(timeline)

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -201,8 +201,9 @@ proc elevatedTokenIdToName*(elevatedTokenId: string): string =
         else: result = "Unknown - " & elevatedTokenId
     return result
 
-proc countLinesInTimeline*(filePath: string): int =
-    echo "Counting total lines. Please wait."
+proc countLinesInTimeline*(filePath: string, quiet:bool = false): int =
+    if not quiet:
+      echo "Counting total lines. Please wait."
     const BufferSize = 4 * 1024 * 1024  # 4 MiB
     var buffer = newString(BufferSize)
     var file = open(filePath)
@@ -217,8 +218,9 @@ proc countLinesInTimeline*(filePath: string): int =
                 inc(count)
     inc(count)
     file.close()
-    echo "Total lines: ", intToStr(count).insertSep(',')
-    echo ""
+    if not quiet:
+        echo "Total lines: ", intToStr(count).insertSep(',')
+        echo ""
     return count
 
 proc getYAMLpathes*(rulesDir: string): seq[string] =

--- a/src/takajopkg/general.nim
+++ b/src/takajopkg/general.nim
@@ -365,7 +365,7 @@ proc checkArgs*(quiet: bool = false, timeline: string, level:string) =
 
 
 proc countJsonlAndStartMsg*(cmdName:string, msg:string, timeline:string):int =
-    echo "Started the Stack " & cmdName & " command"
+    echo "Started the " & cmdName & " command"
     echo ""
     echo "This command will stack " &  msg & "."
     echo ""

--- a/src/takajopkg/listDomains.nim
+++ b/src/takajopkg/listDomains.nim
@@ -2,9 +2,9 @@
 # Graceful error when no domains loaded
 const ListDomainsMsg =
   """
-  Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations.
-  Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains.
-  Domains ending with .lan, .LAN or .local are filtered out.
+Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations.
+Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains.
+Domains ending with .lan, .LAN or .local are filtered out.
   """
 
 type

--- a/src/takajopkg/listDomains.nim
+++ b/src/takajopkg/listDomains.nim
@@ -4,8 +4,7 @@ const ListDomainsMsg =
   """
 Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations.
 Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains.
-Domains ending with .lan, .LAN or .local are filtered out.
-  """
+Domains ending with .lan, .LAN or .local are filtered out."""
 
 type
   ListDomainsCmd* = ref object of AbstractCmd

--- a/src/takajopkg/listDomains.nim
+++ b/src/takajopkg/listDomains.nim
@@ -39,9 +39,10 @@ method resultOutput*(self: ListDomainsCmd)=
     echo "Saved file: " & self.output & " (" & formatFileSize(outputFileSize) & ")"
     echo ""
 
-proc listDomains(includeSubdomains: bool = false, includeWorkstations: bool = false, output: string, quiet: bool = false, timeline: string) =
+proc listDomains(includeSubdomains: bool = false, includeWorkstations: bool = false, skipProgressBar:bool = false, output: string, quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = ListDomainsCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"List Domains",

--- a/src/takajopkg/listDomains.nim
+++ b/src/takajopkg/listDomains.nim
@@ -1,63 +1,51 @@
 # TODO: List up domain info from DNS Server and Client events
 # Graceful error when no domains loaded
-proc listDomains(includeSubdomains: bool = false, includeWorkstations: bool = false, output: string, quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, "informational")
+const ListDomainsMsg =
+  """
+  Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations.
+  Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains.
+  Domains ending with .lan, .LAN or .local are filtered out.
+  """
 
-    echo "Started the List Domains command"
-    echo ""
-    echo "Local queries to workstations are filtered out by default, but can be included with -w, --includeWorkstations."
-    echo "Sub-domains are also filtered out by default, but can be included with -s, --includeSubdomains."
-    echo "Domains ending with .lan, .LAN or .local are filtered out."
-    echo ""
+type
+  ListDomainsCmd* = ref object of AbstractCmd
+      domainHashSet* = initHashSet[string]()
+      includeSubdomains*: bool
+      includeWorkstations*: bool
 
-    let totalLines = countLinesInTimeline(timeline)
+method filter*(self: ListDomainsCmd, x: HayabusaJson):bool =
+    if not (x.Channel == "Sysmon" and x.EventId == 22):
+        return false
+    let domain = x.Details.extractStr("Query")
+    return self.includeWorkstations or (domain.contains('.') and domain != "." and not domain.endsWith(".lan") and
+      not domain.endsWith(".LAN") and not domain.endsWith(".local") and not isIpAddress(domain) and not domain.endsWith('.'))
 
-    echo "Extracting domain queries from Sysmon 22 events. Please wait."
-    echo ""
+method analyze*(self: ListDomainsCmd, x: HayabusaJson) =
+    var domain = x.Details.extractStr("Query")
+    if not self.includeSubdomains:
+        domain = extractDomain(domain)
+    self.domainHashSet.incl(domain)
 
-    var
-        domainHashSet = initHashSet[string]()
-        bar: SuruBar = initSuruBar()
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000)
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        let eventId = jsonLine.EventID
-        let channel = jsonLine.Channel
-        let details = jsonLine.Details
-        # Found a Sysmon 22 DNS Query event
-        if channel == "Sysmon" and eventId == 22:
-            var domain = details.extractStr("Query")
-
-            # If includeWorkstations is false, only add domain if it contains a period
-            # Filter out ".", "*.lan" and "*.LAN"
-            if includeWorkstations or (domain.contains('.') and domain != "." and not domain.endsWith(".lan") and not
-                domain.endsWith(".LAN") and not domain.endsWith(".local") and not isIpAddress(domain) and not domain.endsWith('.')):
-
-                # Do not include subdomains by default so strip the subdomains
-                if not includeSubdomains:
-                    domain = extractDomain(domain)
-                domainHashSet.incl(domain)
-
-    bar.finish()
-
+method resultOutput*(self: ListDomainsCmd)=
     # Save results
-    var outputFile = open(output, fmWrite)
-    for domain in domainHashSet:
+    var outputFile = open(self.output, fmWrite)
+    for domain in self.domainHashSet:
         outputFile.write(domain & "\p")
     let outputFileSize = getFileSize(outputFile)
     outputFile.close()
 
     echo ""
-    echo "Domains: ", intToStr(len(domainHashSet)).insertSep(',')
-    echo "Saved file: " & output & " (" & formatFileSize(outputFileSize) & ")"
+    echo "Domains: ", intToStr(len(self.domainHashSet)).insertSep(',')
+    echo "Saved file: " & self.output & " (" & formatFileSize(outputFileSize) & ")"
     echo ""
-    outputElapsedTime(startTime)
+
+proc listDomains(includeSubdomains: bool = false, includeWorkstations: bool = false, output: string, quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, "informational")
+    let cmd = ListDomainsCmd(
+                timeline: timeline,
+                output: output,
+                name:"List Domains",
+                msg: ListDomainsMsg,
+                includeSubdomains: includeSubdomains,
+                includeWorkstations: includeWorkstations)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/listHashes.nim
+++ b/src/takajopkg/listHashes.nim
@@ -86,7 +86,7 @@ method resultOutput*(self: ListHashesCmd) =
     echo "Import: ", intToStr(self.impHashCount).insertSep(',')
     echo ""
 
-proc listHashes(level: string = "high", output: string, quiet: bool = false, timeline: string) =
+proc listHashes(level: string = "high", skipProgressBar:bool = false, output: string, quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = ListHashesCmd(
                 timeline: timeline,

--- a/src/takajopkg/listHashes.nim
+++ b/src/takajopkg/listHashes.nim
@@ -2,10 +2,10 @@
 # Get hashes from sysmon ID 7 (Image Loaded)
 const ListHashesMsg =
   """
-  This command will extract out unique MD5, SHA1, SHA256 and Import hashes from Sysmon 1 process creation events.
-  By default, a minimum level of high will be used to extract only hashes of processes with a high likelihood of being malicious.
-  You can change the minimum level of alerts with -l, --level (ex: -l low).
-  For example, -l=informational for a minimum level of informational, which will extract out all hashes.
+This command will extract out unique MD5, SHA1, SHA256 and Import hashes from Sysmon 1 process creation events.
+By default, a minimum level of high will be used to extract only hashes of processes with a high likelihood of being malicious.
+You can change the minimum level of alerts with -l, --level (ex: -l low).
+For example, -l=informational for a minimum level of informational, which will extract out all hashes.
   """
 
 type

--- a/src/takajopkg/listHashes.nim
+++ b/src/takajopkg/listHashes.nim
@@ -5,8 +5,7 @@ const ListHashesMsg =
 This command will extract out unique MD5, SHA1, SHA256 and Import hashes from Sysmon 1 process creation events.
 By default, a minimum level of high will be used to extract only hashes of processes with a high likelihood of being malicious.
 You can change the minimum level of alerts with -l, --level (ex: -l low).
-For example, -l=informational for a minimum level of informational, which will extract out all hashes.
-  """
+For example, -l=informational for a minimum level of informational, which will extract out all hashes."""
 
 type
   ListHashesCmd* = ref object of AbstractCmd

--- a/src/takajopkg/listHashes.nim
+++ b/src/takajopkg/listHashes.nim
@@ -1,81 +1,57 @@
 # TODO
 # Get hashes from sysmon ID 7 (Image Loaded)
-proc listHashes(level: string = "high", output: string, quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, "informational")
+const ListHashesMsg =
+  """
+  This command will extract out unique MD5, SHA1, SHA256 and Import hashes from Sysmon 1 process creation events.
+  By default, a minimum level of high will be used to extract only hashes of processes with a high likelihood of being malicious.
+  You can change the minimum level of alerts with -l, --level (ex: -l low).
+  For example, -l=informational for a minimum level of informational, which will extract out all hashes.
+  """
 
-    echo "Started the List Hashes command"
-    echo ""
-    echo "This command will extract out unique MD5, SHA1, SHA256 and Import hashes from Sysmon 1 process creation events."
-    echo "By default, a minimum level of high will be used to extract only hashes of processes with a high likelihood of being malicious."
-    echo "You can change the minimum level of alerts with -l, --level (ex: -l low)."
-    echo "For example, -l=informational for a minimum level of informational, which will extract out all hashes."
-    echo ""
+type
+  ListHashesCmd* = ref object of AbstractCmd
+      level:string
+      md5hashes*, sha1hashes*, sha256hashes*, impHashes* = initHashSet[string]()
+      md5hashCount*, sha1hashCount*, sha256hashCount*, impHashCount* = 0
 
-    let totalLines = countLinesInTimeline(timeline)
+method filter*(self: ListHashesCmd, x: HayabusaJson):bool =
+    return x.Channel == "Sysmon" and x.EventID == 1 and isMinLevel(x.Level, self.level)
 
-    if level == "critical":
-        echo "Scanning for process hashes with an alert level of critical"
-    else:
-        echo "Scanning for process hashes with a minimal alert level of " & level
-    echo ""
+method analyze*(self: ListHashesCmd, x: HayabusaJson) =
+    try:
+        let hashes = x.Details["Hashes"].getStr() # Hashes are not enabled by default so this field may not exist.
+        let pairs = hashes.split(",")  # Split the string into key-value pairs. Ex: MD5=DE9C75F34F47B60A71BBA03760F0579E,SHA256=12F06D3B1601004DB3F7F1A07E7D3AF4CC838E890E0FF50C51E4A0C9366719ED,IMPHASH=336674CB3C8337BDE2C22255345BFF43
+        for pair in pairs:
+            let keyVal = pair.split("=")
+            case keyVal[0]:
+                of "MD5":
+                    self.md5hashes.incl(keyVal[1])
+                    inc self.md5hashCount
+                of "SHA1":
+                    self.sha1hashes.incl(keyVal[1])
+                    inc self.sha1hashCount
+                of "SHA256":
+                    self.sha256hashes.incl(keyVal[1])
+                    inc self.sha256hashCount
+                of "IMPHASH":
+                    self.impHashes.incl(keyVal[1])
+                    inc self.impHashCount
+    except KeyError:
+        discard
 
-    var
-        md5hashes, sha1hashes, sha256hashes, impHashes = initHashSet[string]()
-        hashes = ""
-        md5hashCount, sha1hashCount, sha256hashCount, impHashCount = 0
-        bar: SuruBar = initSuruBar()
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        let eventId = jsonLine.EventID
-        let channel = jsonLine.Channel
-        let eventLevel = jsonLine.Level
-
-        # Found a Sysmon 1 process creation event
-        if channel == "Sysmon" and eventId == 1 and isMinLevel(eventLevel, level) == true:
-            try:
-                hashes = jsonLine.Details["Hashes"].getStr() # Hashes are not enabled by default so this field may not exist.
-                let pairs = hashes.split(",")  # Split the string into key-value pairs. Ex: MD5=DE9C75F34F47B60A71BBA03760F0579E,SHA256=12F06D3B1601004DB3F7F1A07E7D3AF4CC838E890E0FF50C51E4A0C9366719ED,IMPHASH=336674CB3C8337BDE2C22255345BFF43
-                for pair in pairs:
-                    let keyVal = pair.split("=")
-                    case keyVal[0]:
-                        of "MD5":
-                            md5hashes.incl(keyVal[1])
-                            inc md5hashCount
-                        of "SHA1":
-                            sha1hashes.incl(keyVal[1])
-                            inc sha1hashCount
-                        of "SHA256":
-                            sha256hashes.incl(keyVal[1])
-                            inc sha256hashCount
-                        of "IMPHASH":
-                            impHashes.incl(keyVal[1])
-                            inc impHashCount
-            except KeyError:
-                discard
-    bar.finish()
-
-    # Save MD5 results
+method resultOutput*(self: ListHashesCmd) =
+    let output = self.output
     let md5outputFilename = output & "-MD5-hashes.txt"
     var md5outputFile = open(md5outputFilename, fmWrite)
-    for hash in md5hashes:
+    for hash in self.md5hashes:
         md5outputFile.write(hash & "\p")
     md5outputFile.close()
     let md5FileSize = getFileSize(md5outputFilename)
 
     # Save SHA1 results
-    let sha1outputFilename = output & "-SHA1-hashes.txt"
+    let sha1outputFilename = self.output & "-SHA1-hashes.txt"
     var sha1outputFile = open(sha1outputFilename, fmWrite)
-    for hash in sha1hashes:
+    for hash in self.sha1hashes:
         sha1outputFile.write(hash & "\p")
     sha1outputFile.close()
     let sha1FileSize = getFileSize(sha1outputFilename)
@@ -83,7 +59,7 @@ proc listHashes(level: string = "high", output: string, quiet: bool = false, tim
     # Save SHA256 results
     let sha256outputFilename = output & "-SHA256-hashes.txt"
     var sha256outputFile = open(sha256outputFilename, fmWrite)
-    for hash in sha256hashes:
+    for hash in self.sha256hashes:
         sha256outputFile.write(hash & "\p")
     sha256outputFile.close()
     let sha256FileSize = getFileSize(sha256outputFilename)
@@ -91,7 +67,7 @@ proc listHashes(level: string = "high", output: string, quiet: bool = false, tim
     # Save IMPHASH results
     let impHashOutputFilename = output & "-ImportHashes.txt"
     var impHashOutputFile = open(impHashOutputFilename, fmWrite)
-    for hash in impHashes:
+    for hash in self.impHashes:
         impHashOutputFile.write(hash & "\p")
     impHashOutputFile.close()
     let impHashFileSize = getFileSize(impHashOutputFilename)
@@ -104,9 +80,18 @@ proc listHashes(level: string = "high", output: string, quiet: bool = false, tim
     echo impHashOutputFilename & " (" & formatFileSize(impHashFileSize) & ")"
     echo ""
     echo "Hashes:"
-    echo "MD5: ",  intToStr(md5hashCount).insertSep(',')
-    echo "SHA1: ", intToStr(sha1hashCount).insertSep(',')
-    echo "SHA256: ", intToStr(sha256hashCount).insertSep(',')
-    echo "Import: ", intToStr(impHashCount).insertSep(',')
+    echo "MD5: ",  intToStr(self.md5hashCount).insertSep(',')
+    echo "SHA1: ", intToStr(self.sha1hashCount).insertSep(',')
+    echo "SHA256: ", intToStr(self.sha256hashCount).insertSep(',')
+    echo "Import: ", intToStr(self.impHashCount).insertSep(',')
     echo ""
-    outputElapsedTime(startTime)
+
+proc listHashes(level: string = "high", output: string, quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, level)
+    let cmd = ListHashesCmd(
+                timeline: timeline,
+                level: level,
+                output: output,
+                name:"List Hashes",
+                msg: ListHashesMsg)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/listHashes.nim
+++ b/src/takajopkg/listHashes.nim
@@ -89,6 +89,7 @@ method resultOutput*(self: ListHashesCmd) =
 proc listHashes(level: string = "high", skipProgressBar:bool = false, output: string, quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = ListHashesCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 level: level,
                 output: output,

--- a/src/takajopkg/listIpAddresses.nim
+++ b/src/takajopkg/listIpAddresses.nim
@@ -42,7 +42,7 @@ method resultOutput*(self: ListIpAddressesCmd) =
     echo "Saved file: " & self.output & " (" & formatFileSize(outputFileSize) & ")"
     echo ""
 
-proc listIpAddresses(inbound: bool = true, outbound: bool = true, output: string, privateIp: bool = false,  quiet: bool = false, timeline: string) =
+proc listIpAddresses(inbound: bool = true, outbound: bool = true, skipProgressBar:bool = false, output: string, privateIp: bool = false,  quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = ListIpAddressesCmd(
                 timeline: timeline,

--- a/src/takajopkg/listIpAddresses.nim
+++ b/src/takajopkg/listIpAddresses.nim
@@ -1,8 +1,8 @@
 const ListIpAddressesMsg =
     """
-    Inbound traffic is included by default but can be disabled with -i=false.
-    Outbound traffic is included by default but can be disabled with -O=false.
-    Private IP addresses are not included by default but can be enabled with -p.
+Inbound traffic is included by default but can be disabled with -i=false.
+Outbound traffic is included by default but can be disabled with -O=false.
+Private IP addresses are not included by default but can be enabled with -p.
     """
 
 type

--- a/src/takajopkg/listIpAddresses.nim
+++ b/src/takajopkg/listIpAddresses.nim
@@ -24,9 +24,10 @@ method analyze*(self: ListIpAddressesCmd, x: HayabusaJson) =
     var ipAddress = ""
     if self.inbound:
         ipAddress = getJsonValue(x.Details, @["SrcIP"])
+        self.ipHashSet.incl(ipAddress)
     if self.outbound:
         ipAddress = getJsonValue(x.Details, @["TgtIP"])
-    self.ipHashSet.incl(ipAddress)
+        self.ipHashSet.incl(ipAddress)
 
 method resultOutput*(self: ListIpAddressesCmd) =
     # Save results

--- a/src/takajopkg/listIpAddresses.nim
+++ b/src/takajopkg/listIpAddresses.nim
@@ -12,22 +12,21 @@ type
       privateIp*: bool
 
 method filter*(self: ListIpAddressesCmd, x: HayabusaJson):bool =
-    var ipAddress = ""
-    if self.inbound:
-        ipAddress = getJsonValue(x.Details, @["SrcIP"])
-    if self.outbound:
-        ipAddress = getJsonValue(x.Details, @["TgtIP"])
-    return (not isPrivateIP(ipAddress) or self.privateIp) and
-            isMulticast(ipAddress) == false and isLoopback(ipAddress) == false and ipAddress != "Unknown" and ipAddress != "-"
+    return true
 
 method analyze*(self: ListIpAddressesCmd, x: HayabusaJson) =
-    var ipAddress = ""
     if self.inbound:
-        ipAddress = getJsonValue(x.Details, @["SrcIP"])
-        self.ipHashSet.incl(ipAddress)
+        let ipAddress = getJsonValue(x.Details, @["SrcIP"])
+        if (not isPrivateIP(ipAddress) or self.privateIp) and
+            not isMulticast(ipAddress) and not isLoopback(ipAddress) and ipAddress != "Unknown" and ipAddress != "-":
+            self.ipHashSet.incl(ipAddress)
+
+    # Search for events with a TgtIP field if outbound == true
     if self.outbound:
-        ipAddress = getJsonValue(x.Details, @["TgtIP"])
-        self.ipHashSet.incl(ipAddress)
+        let ipAddress = getJsonValue(x.Details, @["TgtIP"])
+        if (not isPrivateIP(ipAddress) or self.privateIp) and
+            not isMulticast(ipAddress) and not isLoopback(ipAddress) and ipAddress != "Unknown" and ipAddress != "-":
+            self.ipHashSet.incl(ipAddress)
 
 method resultOutput*(self: ListIpAddressesCmd) =
     # Save results

--- a/src/takajopkg/listIpAddresses.nim
+++ b/src/takajopkg/listIpAddresses.nim
@@ -2,8 +2,7 @@ const ListIpAddressesMsg =
     """
 Inbound traffic is included by default but can be disabled with -i=false.
 Outbound traffic is included by default but can be disabled with -O=false.
-Private IP addresses are not included by default but can be enabled with -p.
-    """
+Private IP addresses are not included by default but can be enabled with -p."""
 
 type
   ListIpAddressesCmd* = ref object of AbstractCmd

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -6,10 +6,10 @@ type
     ignoreSysmon:bool
     ignoreSecurity:bool
 
-method eventFilter*(self: StackCmdlineCmd, x: HayabusaJson):bool =
+method filter*(self: StackCmdlineCmd, x: HayabusaJson):bool =
     return (x.EventID == 1 and x.Channel == "Sysmon" and not self.ignoreSysmon) or (x.EventID == 4688 and x.Channel == "Sec" and not self.ignoreSecurity)
 
-method eventProcess*(self: StackCmdlineCmd, x: HayabusaJson) =
+method analyze*(self: StackCmdlineCmd, x: HayabusaJson) =
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) = (x.Details["Cmdline"].getStr("N/A"), @[""])
     let (stackKey, otherColumn) = getStackKey(x)
     stackResult(stackKey, self.stack, self.level, x)

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -3,7 +3,6 @@ const StackCmdlineMsg = "This command will stack executed command lines from Sys
 type
   StackCmdlineCmd* = ref object of AbstractCmd
     level* :string
-    header* = @[""]
     stack* = initTable[string, StackRecord]()
     ignoreSysmon:bool
     ignoreSecurity:bool
@@ -17,7 +16,7 @@ method analyze*(self: StackCmdlineCmd, x: HayabusaJson) =
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackCmdlineCmd)=
-    outputResult(self.output, self.name, self.stack)
+    outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
 proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -19,10 +19,11 @@ method analyze*(self: StackCmdlineCmd, x: HayabusaJson) =
 method resultOutput*(self: StackCmdlineCmd)=
     outputResult(self.output, self.name, self.stack)
 
-proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackCmdlineCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"Cmdlines",

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -16,7 +16,7 @@ method analyze*(self: StackCmdlineCmd, x: HayabusaJson) =
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackCmdlineCmd)=
-    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, isMinColumns=true)
 
 proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -25,7 +25,7 @@ proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecu
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name:"Cmdlines",
+                name:"Stack Cmdlines",
                 msg: StackCmdlineMsg,
                 ignoreSysmon: ignoreSysmon,
                 ignoreSecurity: ignoreSecurity)

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -18,8 +18,13 @@ method resultOutput*(self: StackCmdlineCmd)=
     outputResult(self.output, self.name, self.stack)
 
 proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let cmd = StackCmdlineCmd(level:level, timeline:timeline, output:output, name:"Cmdlines", msg:"executed command lines from Sysmon 1 and Security 4688 events", ignoreSysmon:ignoreSysmon, ignoreSecurity:ignoreSecurity)
+    let cmd = StackCmdlineCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name:"Cmdlines",
+                msg: "executed command lines from Sysmon 1 and Security 4688 events",
+                ignoreSysmon: ignoreSysmon,
+                ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackCmdlines.nim
+++ b/src/takajopkg/stackCmdlines.nim
@@ -1,3 +1,5 @@
+const StackCmdlineMsg = "This command will stack executed command lines from Sysmon 1 and Security 4688 events."
+
 type
   StackCmdlineCmd* = ref object of AbstractCmd
     level* :string
@@ -24,7 +26,7 @@ proc stackCmdlines(level: string = "low", ignoreSysmon: bool = false, ignoreSecu
                 timeline: timeline,
                 output: output,
                 name:"Cmdlines",
-                msg: "executed command lines from Sysmon 1 and Security 4688 events",
+                msg: StackCmdlineMsg,
                 ignoreSysmon: ignoreSysmon,
                 ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackCommon.nim
+++ b/src/takajopkg/stackCommon.nim
@@ -22,23 +22,23 @@ type StackRecord* = ref object
     otherColumn = newSeq[string]()
 
 proc calcLevelOrder(x: StackRecord): int =
-  result = 0
-  if "crit" in x.levels:
-      result = LEVEL_ORDER["crit"]
-  elif "high" in x.levels:
-      result = LEVEL_ORDER["high"]
-  elif "med" in x.levels:
-      result = LEVEL_ORDER["med"]
-  elif "low" in x.levels:
-      result = LEVEL_ORDER["low"]
-  elif "info" in x.levels:
-      result = LEVEL_ORDER["info"]
+    result = 0
+    if "crit" in x.levels:
+        result = LEVEL_ORDER["crit"]
+    elif "high" in x.levels:
+        result = LEVEL_ORDER["high"]
+    elif "med" in x.levels:
+        result = LEVEL_ORDER["med"]
+    elif "low" in x.levels:
+        result = LEVEL_ORDER["low"]
+    elif "info" in x.levels:
+        result = LEVEL_ORDER["info"]
 
 proc levelCmp(x, y: (string, int)): int =
-  cmp(LEVEL_ORDER[x[0]], LEVEL_ORDER[y[0]]) * -1
+    cmp(LEVEL_ORDER[x[0]], LEVEL_ORDER[y[0]]) * -1
 
 proc buildCountStr(x:(string, int)): string =
-  x[0] & " (" & intToStr(x[1]) & ")"
+    x[0] & " (" & intToStr(x[1]) & ")"
 
 proc recordCmp(x, y: StackRecord): int =
   result = cmp(x.levelsOrder, y.levelsOrder) * -1
@@ -52,13 +52,13 @@ proc recordCmp(x, y: StackRecord): int =
       result = cmp(x.key, y.key)
 
 proc buildCSVRecord(x: StackRecord, isMinColumns:bool = false): seq[string] =
-  let levelsStr = toSeq(pairs(x.levels)).sorted(levelCmp).map(buildCountStr).join(" | ")
-  let ruleTitlesStr = toSeq(pairs(x.ruleTitles)).sorted.map(buildCountStr).join(" | ")
-  if x.otherColumn.len == 0:
-    if isMinColumns:
-        return @[intToStr(x.count), x.key, levelsStr, ruleTitlesStr]
-    return @[intToStr(x.count), x.channel, x.eid, x.key, levelsStr, ruleTitlesStr]
-  return concat(@[intToStr(x.count), x.channel, x.eid], x.otherColumn, @[levelsStr, ruleTitlesStr])
+    let levelsStr = toSeq(pairs(x.levels)).sorted(levelCmp).map(buildCountStr).join(" | ")
+    let ruleTitlesStr = toSeq(pairs(x.ruleTitles)).sorted.map(buildCountStr).join(" | ")
+    if x.otherColumn.len == 0:
+      if isMinColumns:
+          return @[intToStr(x.count), x.key, levelsStr, ruleTitlesStr]
+      return @[intToStr(x.count), x.channel, x.eid, x.key, levelsStr, ruleTitlesStr]
+    return concat(@[intToStr(x.count), x.channel, x.eid], x.otherColumn, @[levelsStr, ruleTitlesStr])
 
 proc stackResult*(key:string, stack: var Table[string, StackRecord], minLevel:string, jsonLine:HayabusaJson, otherColumn:seq[string] = @[]) =
     if key.len() == 0 or key == "-" or key == "Unknown" or key == "n/a":

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -5,10 +5,10 @@ type
     stack* = initTable[string, StackRecord]()
     sourceComputers:bool
 
-method eventFilter*(self: StackComputersCmd, x: HayabusaJson):bool =
+method filter*(self: StackComputersCmd, x: HayabusaJson):bool =
     return true
 
-method eventProcess*(self: StackComputersCmd, x: HayabusaJson)=
+method analyze*(self: StackComputersCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         var stackKey = x.Computer
         if self.sourceComputers:

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -21,8 +21,6 @@ method resultOutput*(self: StackComputersCmd)=
     outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
 proc stackComputers(level: string = "informational", sourceComputers: bool = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
     let cmd = StackComputersCmd(level:level, timeline:timeline, output:output, name:"Computers", msg:"the Computer (default) or SrcComp fields as well as show alert information", sourceComputers:sourceComputers)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -19,7 +19,7 @@ method analyze*(self: StackComputersCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackComputersCmd)=
-    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, isMinColumns=true)
 
 proc stackComputers(level: string = "informational", sourceComputers: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -28,7 +28,7 @@ proc stackComputers(level: string = "informational", sourceComputers: bool = fal
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "Computers",
+                name: "Stack Computers",
                 msg: StackComputerMsg,
                 sourceComputers: sourceComputers)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -22,10 +22,11 @@ method analyze*(self: StackComputersCmd, x: HayabusaJson)=
 method resultOutput*(self: StackComputersCmd)=
     outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
-proc stackComputers(level: string = "informational", sourceComputers: bool = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackComputers(level: string = "informational", sourceComputers: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackComputersCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "Computers",

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -3,7 +3,6 @@ const StackComputerMsg = "This command will stack the Computer (default) or SrcC
 type
   StackComputersCmd* = ref object of AbstractCmd
     level* :string
-    header* = @[""]
     stack* = initTable[string, StackRecord]()
     sourceComputers:bool
 

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -1,3 +1,5 @@
+const StackComputerMsg = "This command will stack the Computer (default) or SrcComp fields as well as show alert information."
+
 type
   StackComputersCmd* = ref object of AbstractCmd
     level* :string
@@ -22,5 +24,11 @@ method resultOutput*(self: StackComputersCmd)=
 
 proc stackComputers(level: string = "informational", sourceComputers: bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
-    let cmd = StackComputersCmd(level:level, timeline:timeline, output:output, name:"Computers", msg:"the Computer (default) or SrcComp fields as well as show alert information", sourceComputers:sourceComputers)
+    let cmd = StackComputersCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "Computers",
+                msg: StackComputerMsg,
+                sourceComputers: sourceComputers)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackComputers.nim
+++ b/src/takajopkg/stackComputers.nim
@@ -1,13 +1,28 @@
+type
+  StackComputersCmd* = ref object of AbstractCmd
+    level* :string
+    header* = @[""]
+    stack* = initTable[string, StackRecord]()
+    sourceComputers:bool
+
+method eventFilter*(self: StackComputersCmd, x: HayabusaJson):bool =
+    return true
+
+method eventProcess*(self: StackComputersCmd, x: HayabusaJson)=
+    let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
+        var stackKey = x.Computer
+        if self.sourceComputers:
+            stackKey = getJsonValue(x.Details, @["SrcComp"])
+        return (stackKey, @[""])
+    let (stackKey, otherColumn) = getStackKey(x)
+    stackResult(stackKey, self.stack, self.level, x)
+
+method resultOutput*(self: StackComputersCmd)=
+    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+
 proc stackComputers(level: string = "informational", sourceComputers: bool = false, output: string = "", quiet: bool = false, timeline: string) =
     let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let totalLines = countJsonlAndStartMsg("Computers", "the Computer (default) or SrcComp fields as well as show alert information", timeline)
-    let eventFilter = proc(x: HayabusaJson): bool = true
-    let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
-        var stackKey = x.Computer
-        if sourceComputers:
-            stackKey = getJsonValue(x.Details, @["SrcComp"])
-        return (stackKey, @[])
-    let stack = processJSONL(eventFilter, getStackKey, totalLines, timeline, level)
-    outputResult(output, "Computer", stack, isMinColumns=true)
+    let cmd = StackComputersCmd(level:level, timeline:timeline, output:output, name:"Computers", msg:"the Computer (default) or SrcComp fields as well as show alert information", sourceComputers:sourceComputers)
+    cmd.analyzeJSONLFile()
     outputElapsedTime(startTime)

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -20,7 +20,7 @@ method analyze*(self: StackDNSCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x, otherColumn)
 
 method resultOutput*(self: StackDNSCmd)=
-    outputResult(self.output, self.name, self.stack, self.header)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, self.header)
 
 proc stackDNS(level: string = "informational", skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -29,6 +29,6 @@ proc stackDNS(level: string = "informational", skipProgressBar:bool = false, out
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "DNS",
+                name: "Stack DNS",
                 msg: StackDNSMsg)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -1,14 +1,28 @@
-proc stackDNS(level: string = "informational", output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, level)
-    let totalLines = countJsonlAndStartMsg("DNS", "DNS queries and responses from Sysmon 22 events", timeline)
-    let eventFilter = proc(x: HayabusaJson): bool = x.EventID == 22 and x.Channel == "Sysmon"
+type
+  StackDNSCmd* = ref object of AbstractCmd
+    level* :string
+    header* = @["Image", "Query", "Result"]
+    stack* = initTable[string, StackRecord]()
+
+method eventFilter*(self: StackDNSCmd, x: HayabusaJson):bool =
+    return x.EventID == 22 and x.Channel == "Sysmon"
+
+method eventProcess*(self: StackDNSCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         let pro = x.Details["Proc"].getStr("N/A")
         let que = x.Details["Query"].getStr("N/A")
         let res = x.Details["Result"].getStr("N/A")
         let stackKey = pro & "->" & que & "->" & res
         return (stackKey, @[pro, que, res])
-    let stack = processJSONL(eventFilter, getStackKey, totalLines, timeline, level)
-    outputResult(output, "DNS", stack, @["Image", "Query", "Result"])
+    let (stackKey, otherColumn) = getStackKey(x)
+    stackResult(stackKey, self.stack, self.level, x, otherColumn)
+
+method resultOutput*(self: StackDNSCmd)=
+    outputResult(self.output, self.name, self.stack, self.header)
+
+proc stackDNS(level: string = "informational", output: string = "", quiet: bool = false, timeline: string) =
+    let startTime = epochTime()
+    checkArgs(quiet, timeline, level)
+    let cmd = StackDNSCmd(level:level, timeline:timeline, output:output, name:"DNS", msg:"DNS queries and responses from Sysmon 22 events")
+    cmd.analyzeJSONLFile()
     outputElapsedTime(startTime)

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -22,7 +22,13 @@ method analyze*(self: StackDNSCmd, x: HayabusaJson)=
 method resultOutput*(self: StackDNSCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
-proc stackDNS(level: string = "informational", output: string = "", quiet: bool = false, timeline: string) =
+proc stackDNS(level: string = "informational", skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
-    let cmd = StackDNSCmd(level: level, timeline: timeline, output: output, name: "DNS", msg: StackDNSMsg)
+    let cmd = StackDNSCmd(
+                level: level,
+                skipProgressBar: skipProgressBar,
+                timeline: timeline,
+                output: output,
+                name: "DNS",
+                msg: StackDNSMsg)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -1,3 +1,5 @@
+const StackDNSMsg = "This command will stack the DNS queries and responses from Sysmon 22 events."
+
 type
   StackDNSCmd* = ref object of AbstractCmd
     level* :string
@@ -22,10 +24,5 @@ method resultOutput*(self: StackDNSCmd)=
 
 proc stackDNS(level: string = "informational", output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
-    let cmd = StackDNSCmd(
-                level: level,
-                timeline: timeline,
-                output: output,
-                name: "DNS",
-                msg: "DNS queries and responses from Sysmon 22 events")
+    let cmd = StackDNSCmd(level: level, timeline: timeline, output: output, name: "DNS", msg: StackDNSMsg)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -4,10 +4,10 @@ type
     header* = @["Image", "Query", "Result"]
     stack* = initTable[string, StackRecord]()
 
-method eventFilter*(self: StackDNSCmd, x: HayabusaJson):bool =
+method filter*(self: StackDNSCmd, x: HayabusaJson):bool =
     return x.EventID == 22 and x.Channel == "Sysmon"
 
-method eventProcess*(self: StackDNSCmd, x: HayabusaJson)=
+method analyze*(self: StackDNSCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         let pro = x.Details["Proc"].getStr("N/A")
         let que = x.Details["Query"].getStr("N/A")

--- a/src/takajopkg/stackDNS.nim
+++ b/src/takajopkg/stackDNS.nim
@@ -21,8 +21,11 @@ method resultOutput*(self: StackDNSCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
 proc stackDNS(level: string = "informational", output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let cmd = StackDNSCmd(level:level, timeline:timeline, output:output, name:"DNS", msg:"DNS queries and responses from Sysmon 22 events")
+    let cmd = StackDNSCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "DNS",
+                msg: "DNS queries and responses from Sysmon 22 events")
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -21,10 +21,11 @@ method analyze*(self: StackIpAddressesCmd, x: HayabusaJson)=
 method resultOutput*(self: StackIpAddressesCmd)=
     outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
-proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackIpAddressesCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "IpAddresses",

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -5,12 +5,12 @@ type
     stack* = initTable[string, StackRecord]()
     targetIpAddresses:bool
 
-method eventFilter*(self: StackIpAddressesCmd, x: HayabusaJson):bool =
+method filter*(self: StackIpAddressesCmd, x: HayabusaJson):bool =
     let key = if self.targetIpAddresses: "TgtIP" else: "SrcIP"
     let ip = getJsonValue(x.Details, @[key])
     return ip != "127.0.0.1" and ip != "::1"
 
-method eventProcess*(self: StackIpAddressesCmd, x: HayabusaJson)=
+method analyze*(self: StackIpAddressesCmd, x: HayabusaJson)=
     let key = if self.targetIpAddresses: "TgtIP" else: "SrcIP"
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) = (getJsonValue(x.Details, @[key]), @[""])
     let (stackKey, otherColumn) = getStackKey(x)

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -18,7 +18,7 @@ method analyze*(self: StackIpAddressesCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackIpAddressesCmd)=
-    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, isMinColumns=true)
 
 proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -27,7 +27,7 @@ proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool =
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "IpAddresses",
+                name: "Stack IpAddresses",
                 msg: StackIpAddressesMsg,
                 targetIpAddresses: targetIpAddresses)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -1,3 +1,5 @@
+const StackIpAddressesMsg = "This command will stack the SrcIP (default) or TgtIP fields as well as show alert information."
+
 type
   StackIpAddressesCmd* = ref object of AbstractCmd
     level* :string
@@ -26,6 +28,6 @@ proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool =
                 timeline: timeline,
                 output: output,
                 name: "IpAddresses",
-                msg: "the SrcIP (default) or TgtIP fields as well as show alert information",
+                msg: StackIpAddressesMsg,
                 targetIpAddresses: targetIpAddresses)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -20,8 +20,12 @@ method resultOutput*(self: StackIpAddressesCmd)=
     outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
 proc stackIpAddresses(level: string = "informational", targetIpAddresses: bool = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let cmd = StackIpAddressesCmd(level:level, timeline:timeline, output:output, name:"IpAddresses", msg:"the SrcIP (default) or TgtIP fields as well as show alert information", targetIpAddresses:targetIpAddresses)
+    let cmd = StackIpAddressesCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "IpAddresses",
+                msg: "the SrcIP (default) or TgtIP fields as well as show alert information",
+                targetIpAddresses: targetIpAddresses)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackIpAddresses.nim
+++ b/src/takajopkg/stackIpAddresses.nim
@@ -3,7 +3,6 @@ const StackIpAddressesMsg = "This command will stack the SrcIP (default) or TgtI
 type
   StackIpAddressesCmd* = ref object of AbstractCmd
     level* :string
-    header* = @[""]
     stack* = initTable[string, StackRecord]()
     targetIpAddresses:bool
 

--- a/src/takajopkg/stackLogons.nim
+++ b/src/takajopkg/stackLogons.nim
@@ -1,6 +1,7 @@
 # TODO
 # Output to stdout in tables (Target User, Target Computer, Logon Type, Source Computer)
 # Remove local logins
+const StackLogonsMsg = "This command will stack logons based on target user, target computer, source IP address and source computer from Security 4624 events.\nLocal source IP addresses are not included by default but can be enabled with -l, --localSrcIpAddresses."
 
 type
   StackLogonsCmd* = ref object of AbstractCmd
@@ -73,6 +74,6 @@ proc stackLogons(localSrcIpAddresses = false, output: string = "", quiet: bool =
                 timeline: timeline,
                 output: output,
                 name:"Logons",
-                msg: "logons based on target user, target computer, source IP address and source computer from Security 4624 events.\nLocal source IP addresses are not included by default but can be enabled with -l, --localSrcIpAddresses.",
+                msg: StackLogonsMsg,
                 localSrcIpAddresses: localSrcIpAddresses)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackLogons.nim
+++ b/src/takajopkg/stackLogons.nim
@@ -2,62 +2,33 @@
 # Output to stdout in tables (Target User, Target Computer, Logon Type, Source Computer)
 # Remove local logins
 
-proc stackLogons(localSrcIpAddresses = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, "informational")
+type
+  StackLogonsCmd* = ref object of AbstractCmd
+      seqOfStrings*: seq[string]
+      uniqueLogons = 0
+      localSrcIpAddresses:bool
 
-    echo "Started the Stack Logons command"
-    echo ""
-    echo "This command will stack logons based on target user, target computer, source IP address and source computer from Security 4624 events."
-    echo "Local source IP addresses are not included by default but can be enabled with -l, --localSrcIpAddresses."
-    echo ""
+method filter*(self: StackLogonsCmd, x: HayabusaJson):bool =
+    return isEID_4624(x.RuleTitle)
 
-    let totalLines = countLinesInTimeline(timeline)
-    echo "Scanning the Hayabusa timeline. Please wait."
-    echo ""
+method analyze*(self: StackLogonsCmd, x: HayabusaJson) =
+    let
+      tgtUser = getJsonValue(x.Details, @["TgtUser"])
+      tgtComp = x.Computer
+      logonType = getJsonValue(x.Details, @["Type"])
+      srcIP = getJsonValue(x.Details, @["SrcIP"])
+      srcComp = getJsonValue(x.Details, @["SrcComp"])
 
-    var
-        EID_4624_count = 0
-        tgtUser, tgtComp, logonType, srcIP, srcComp = ""
-        seqOfStrings: seq[string]
-        bar: SuruBar = initSuruBar()
-        uniqueLogons = 0
-        outputFileSize: int64
+    if not self.localSrcIpAddresses and isLocalIP(srcIP):
+        discard
+    else:
+        self.seqOfStrings.add(tgtUser & "," & tgtComp & "," & logonType & "," & srcIP & "," & srcComp)
 
-    bar[0].total = totalLines
-    bar.setup()
-
-    # Loop through JSON lines
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        let ruleTitle = jsonLine.RuleTitle
-
-        # EID 4624 Successful Logon
-        if isEID_4624(ruleTitle) == true:
-            inc EID_4624_count
-
-            tgtUser = getJsonValue(jsonLine.Details, @["TgtUser"])
-            tgtComp = jsonLine.Computer
-            logonType = getJsonValue(jsonLine.Details, @["Type"])
-            srcIP = getJsonValue(jsonLine.Details, @["SrcIP"])
-            srcComp = getJsonValue(jsonLine.Details, @["SrcComp"])
-
-            if not localSrcIpAddresses and isLocalIP(srcIP):
-                discard
-            else:
-                seqOfStrings.add(tgtUser & "," & tgtComp & "," & logonType & "," & srcIP & "," & srcComp)
-    bar.finish()
-    echo ""
-
+method resultOutput*(self: StackLogonsCmd) =
     var countsTable: Table[string, int] = initTable[string, int]()
 
     # Add a count for each time the unique string was found
-    for string in seqOfStrings:
+    for string in self.seqOfStrings:
         if not countsTable.hasKey(string):
             countsTable[string] = 0
         countsTable[string] += 1
@@ -71,28 +42,37 @@ proc stackLogons(localSrcIpAddresses = false, output: string = "", quiet: bool =
     seqOfPairs.sort(proc (x, y: (string, int)): int = y[1] - x[1])
 
     # Print results to screen
-    if output == "":
+    var outputFileSize = 0
+    if self.output == "":
         # Print the sorted counts with unique strings
         for (string, count) in seqOfPairs:
-            inc uniqueLogons
+            inc self.uniqueLogons
             var commaDelimitedStr = $count & "," & string
             commaDelimitedStr = replace(commaDelimitedStr, ",", " | ")
             echo commaDelimitedStr
     # Save to CSV file
     else:
-        let outputFile = open(output, fmWrite)
+        let outputFile = open(self.output, fmWrite)
         # Write headers
         writeLine(outputFile, "Count,TgtUser,TgtComp,LogonType,SrcIP,SrcComp")
 
         # Write results
         for (string, count) in seqOfPairs:
-            inc uniqueLogons
+            inc self.uniqueLogons
             writeLine(outputFile, $count & "," & string)
         outputFileSize = getFileSize(outputFile)
         close(outputFile)
 
     echo ""
-    echo "Unique logons: " & $uniqueLogons
-    echo "Saved file: " & output & " (" & formatFileSize(outputFileSize) & ")"
-    echo ""
-    outputElapsedTime(startTime)
+    echo "Unique logons: " & $self.uniqueLogons
+    echo "Saved file: " & self.output & " (" & formatFileSize(outputFileSize) & ")"
+
+proc stackLogons(localSrcIpAddresses = false, output: string = "", quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, "informational")
+    let cmd = StackLogonsCmd(
+                timeline: timeline,
+                output: output,
+                name:"Logons",
+                msg: "logons based on target user, target computer, source IP address and source computer from Security 4624 events.\nLocal source IP addresses are not included by default but can be enabled with -l, --localSrcIpAddresses.",
+                localSrcIpAddresses: localSrcIpAddresses)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackLogons.nim
+++ b/src/takajopkg/stackLogons.nim
@@ -68,9 +68,10 @@ method resultOutput*(self: StackLogonsCmd) =
     echo "Unique logons: " & $self.uniqueLogons
     echo "Saved file: " & self.output & " (" & formatFileSize(outputFileSize) & ")"
 
-proc stackLogons(localSrcIpAddresses = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackLogons(localSrcIpAddresses = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = StackLogonsCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"Logons",

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -1,3 +1,5 @@
+const StackProcessesMsg = "This command will stack the executed processes from Sysmon 1 and Security 4688 events."
+
 type
   StackProcessesCmd* = ref object of AbstractCmd
     level* :string
@@ -19,5 +21,12 @@ method resultOutput*(self: StackProcessesCmd) =
 
 proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
-    let cmd = StackProcessesCmd(level:level, timeline:timeline, output:output, name:"Processes", msg:"executed processes from Sysmon 1 and Security 4688 events", ignoreSysmon:ignoreSysmon, ignoreSecurity:ignoreSecurity)
+    let cmd = StackProcessesCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "Processes",
+                msg: StackProcessesMsg,
+                ignoreSysmon: ignoreSysmon,
+                ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -3,7 +3,6 @@ const StackProcessesMsg = "This command will stack the executed processes from S
 type
   StackProcessesCmd* = ref object of AbstractCmd
     level* :string
-    header* = @[""]
     stack* = initTable[string, StackRecord]()
     ignoreSysmon:bool
     ignoreSecurity:bool
@@ -17,7 +16,7 @@ method analyze*(self: StackProcessesCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackProcessesCmd) =
-    outputResult(self.output, self.name, self.stack)
+    outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
 proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -1,9 +1,25 @@
+type
+  StackProcessesCmd* = ref object of AbstractCmd
+    level* :string
+    header* = @[""]
+    stack* = initTable[string, StackRecord]()
+    ignoreSysmon:bool
+    ignoreSecurity:bool
+
+method eventFilter*(self: StackProcessesCmd, x: HayabusaJson):bool =
+    return (x.EventID == 1 and not self.ignoreSysmon and x.Channel == "Sysmon") or (x.EventID == 4688 and not self.ignoreSecurity and x.Channel == "Sec")
+
+method eventProcess*(self: StackProcessesCmd, x: HayabusaJson)=
+    let getStackKey = proc(x: HayabusaJson): (string, seq[string]) = (x.Details["Proc"].getStr("N/A"), @[""])
+    let (stackKey, otherColumn) = getStackKey(x)
+    stackResult(stackKey, self.stack, self.level, x)
+
+method resultOutput*(self: StackProcessesCmd) =
+    outputResult(self.output, self.name, self.stack)
+
 proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
     let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let totalLines = countJsonlAndStartMsg("Processes", "executed processes from Sysmon 1 and Security 4688 events", timeline)
-    let eventFilter = proc(x: HayabusaJson): bool = (x.EventID == 1 and not ignoreSysmon and x.Channel == "Sysmon") or (x.EventID == 4688 and not ignoreSecurity and x.Channel == "Sec")
-    let getStackKey = proc(x: HayabusaJson): (string, seq[string]) = (x.Details["Proc"].getStr("N/A"), @[])
-    let stack = processJSONL(eventFilter, getStackKey, totalLines, timeline, level)
-    outputResult(output, "Process", stack)
+    let cmd = StackProcessesCmd(level:level, timeline:timeline, output:output, name:"Processes", msg:"executed processes from Sysmon 1 and Security 4688 events", ignoreSysmon:ignoreSysmon, ignoreSecurity:ignoreSecurity)
+    cmd.analyzeJSONLFile()
     outputElapsedTime(startTime)

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -16,7 +16,7 @@ method analyze*(self: StackProcessesCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackProcessesCmd) =
-    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, isMinColumns=true)
 
 proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -25,7 +25,7 @@ proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSec
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "Processes",
+                name: "Stack Processes",
                 msg: StackProcessesMsg,
                 ignoreSysmon: ignoreSysmon,
                 ignoreSecurity: ignoreSecurity)

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -6,10 +6,10 @@ type
     ignoreSysmon:bool
     ignoreSecurity:bool
 
-method eventFilter*(self: StackProcessesCmd, x: HayabusaJson):bool =
+method filter*(self: StackProcessesCmd, x: HayabusaJson):bool =
     return (x.EventID == 1 and not self.ignoreSysmon and x.Channel == "Sysmon") or (x.EventID == 4688 and not self.ignoreSecurity and x.Channel == "Sec")
 
-method eventProcess*(self: StackProcessesCmd, x: HayabusaJson)=
+method analyze*(self: StackProcessesCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) = (x.Details["Proc"].getStr("N/A"), @[""])
     let (stackKey, otherColumn) = getStackKey(x)
     stackResult(stackKey, self.stack, self.level, x)

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -18,8 +18,6 @@ method resultOutput*(self: StackProcessesCmd) =
     outputResult(self.output, self.name, self.stack)
 
 proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
     let cmd = StackProcessesCmd(level:level, timeline:timeline, output:output, name:"Processes", msg:"executed processes from Sysmon 1 and Security 4688 events", ignoreSysmon:ignoreSysmon, ignoreSecurity:ignoreSecurity)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackProcesses.nim
+++ b/src/takajopkg/stackProcesses.nim
@@ -19,10 +19,11 @@ method analyze*(self: StackProcessesCmd, x: HayabusaJson)=
 method resultOutput*(self: StackProcessesCmd) =
     outputResult(self.output, self.name, self.stack)
 
-proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackProcesses(level: string = "low", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackProcessesCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "Processes",

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -6,10 +6,10 @@ type
     ignoreSystem:bool
     ignoreSecurity:bool
 
-method eventFilter*(self: StackServicesCmd, x: HayabusaJson):bool =
+method filter*(self: StackServicesCmd, x: HayabusaJson):bool =
     return (x.EventID == 7045 and not self.ignoreSystem and x.Channel == "Sys") or (x.EventID == 4697 and not self.ignoreSecurity and x.Channel == "Sec")
 
-method eventProcess*(self: StackServicesCmd, x: HayabusaJson)=
+method analyze*(self: StackServicesCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         let svc = x.Details["Svc"].getStr("N/A")
         let pat = x.Details["Path"].getStr("N/A")

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -22,8 +22,13 @@ method resultOutput*(self: StackServicesCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
 proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false,output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let cmd = StackServicesCmd(level:level, timeline:timeline, output:output, name:"Services", msg:"service names and paths from System 7045 and Security 4697 events", ignoreSystem:ignoreSystem, ignoreSecurity:ignoreSecurity)
+    let cmd = StackServicesCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "Services",
+                msg: "service names and paths from System 7045 and Security 4697 events",
+                ignoreSystem: ignoreSystem,
+                ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -21,7 +21,7 @@ method analyze*(self: StackServicesCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x, otherColumn=otherColumn)
 
 method resultOutput*(self: StackServicesCmd)=
-    outputResult(self.output, self.name, self.stack, self.header)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, self.header)
 
 proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -30,7 +30,7 @@ proc stackServices(level: string = "informational", ignoreSystem: bool = false, 
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "Services",
+                name: "Stack Services",
                 msg: StackServicesMsg,
                 ignoreSystem: ignoreSystem,
                 ignoreSecurity: ignoreSecurity)

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -1,3 +1,5 @@
+const StackServicesMsg = "This command will stack the service names and paths from System 7045 and Security 4697 events"
+
 type
   StackServicesCmd* = ref object of AbstractCmd
     level* :string
@@ -28,7 +30,7 @@ proc stackServices(level: string = "informational", ignoreSystem: bool = false, 
                 timeline: timeline,
                 output: output,
                 name: "Services",
-                msg: "service names and paths from System 7045 and Security 4697 events",
+                msg: StackServicesMsg,
                 ignoreSystem: ignoreSystem,
                 ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -1,13 +1,29 @@
-proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false,output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, level)
-    let totalLines = countJsonlAndStartMsg("Services", "service names and paths from System 7045 and Security 4697 events", timeline)
-    let eventFilter = proc(x: HayabusaJson): bool = (x.EventID == 7045 and not ignoreSystem and x.Channel == "Sys") or (x.EventID == 4697 and not ignoreSecurity and x.Channel == "Sec")
+type
+  StackServicesCmd* = ref object of AbstractCmd
+    level* :string
+    header* = @["ServiceName", "Path"]
+    stack* = initTable[string, StackRecord]()
+    ignoreSystem:bool
+    ignoreSecurity:bool
+
+method eventFilter*(self: StackServicesCmd, x: HayabusaJson):bool =
+    return (x.EventID == 7045 and not self.ignoreSystem and x.Channel == "Sys") or (x.EventID == 4697 and not self.ignoreSecurity and x.Channel == "Sec")
+
+method eventProcess*(self: StackServicesCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         let svc = x.Details["Svc"].getStr("N/A")
         let pat = x.Details["Path"].getStr("N/A")
         let stackKey = svc & " -> " & pat
         return (stackKey, @[svc, pat])
-    let stack = processJSONL(eventFilter, getStackKey, totalLines, timeline, level)
-    outputResult(output, "Service", stack, @["ServiceName", "Path"])
+    let (stackKey, otherColumn) = getStackKey(x)
+    stackResult(stackKey, self.stack, self.level, x, otherColumn=otherColumn)
+
+method resultOutput*(self: StackServicesCmd)=
+    outputResult(self.output, self.name, self.stack, self.header)
+
+proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false,output: string = "", quiet: bool = false, timeline: string) =
+    let startTime = epochTime()
+    checkArgs(quiet, timeline, level)
+    let cmd = StackServicesCmd(level:level, timeline:timeline, output:output, name:"Services", msg:"service names and paths from System 7045 and Security 4697 events", ignoreSystem:ignoreSystem, ignoreSecurity:ignoreSecurity)
+    cmd.analyzeJSONLFile()
     outputElapsedTime(startTime)

--- a/src/takajopkg/stackServices.nim
+++ b/src/takajopkg/stackServices.nim
@@ -23,10 +23,11 @@ method analyze*(self: StackServicesCmd, x: HayabusaJson)=
 method resultOutput*(self: StackServicesCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
-proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false,output: string = "", quiet: bool = false, timeline: string) =
+proc stackServices(level: string = "informational", ignoreSystem: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackServicesCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "Services",

--- a/src/takajopkg/stackTasks.nim
+++ b/src/takajopkg/stackTasks.nim
@@ -37,8 +37,13 @@ method resultOutput*(self: StackTasksCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
 proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
-    let cmd = StackTasksCmd(level:level, timeline:timeline, output:output, name:"Tasks", msg:"new scheduled tasks from Security 4698 events", ignoreSysmon:ignoreSysmon, ignoreSecurity:ignoreSecurity)
+    let cmd = StackTasksCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "Tasks",
+                msg: "new scheduled tasks from Security 4698 events",
+                ignoreSysmon: ignoreSysmon,
+                ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackTasks.nim
+++ b/src/takajopkg/stackTasks.nim
@@ -1,3 +1,5 @@
+const StackTasksMsg = "This command will stack new scheduled tasks from Security 4698 events"
+
 type
   StackTasksCmd* = ref object of AbstractCmd
     level* :string
@@ -43,7 +45,7 @@ proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ign
                 timeline: timeline,
                 output: output,
                 name: "Tasks",
-                msg: "new scheduled tasks from Security 4698 events",
+                msg: StackTasksMsg,
                 ignoreSysmon: ignoreSysmon,
                 ignoreSecurity: ignoreSecurity)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackTasks.nim
+++ b/src/takajopkg/stackTasks.nim
@@ -38,10 +38,11 @@ method analyze*(self: StackTasksCmd, x: HayabusaJson)=
 method resultOutput*(self: StackTasksCmd)=
     outputResult(self.output, self.name, self.stack, self.header)
 
-proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ignoreSecurity: bool = false, output: string = "", quiet: bool = false, timeline: string) =
+proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackTasksCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "Tasks",

--- a/src/takajopkg/stackTasks.nim
+++ b/src/takajopkg/stackTasks.nim
@@ -6,13 +6,13 @@ type
     ignoreSysmon:bool
     ignoreSecurity:bool
 
-method eventFilter*(self: StackTasksCmd, x: HayabusaJson):bool =
+method filter*(self: StackTasksCmd, x: HayabusaJson):bool =
     return x.EventID == 4698 and x.Channel == "Sec"
 
 proc decodeEntity*(txt: string): string =
    return txt.replace("&amp;","&").replace("&lt;","<").replace("&gt;",">").replace("&quot;","\"").replace("&apos;","'")
 
-method eventProcess*(self: StackTasksCmd, x: HayabusaJson)=
+method analyze*(self: StackTasksCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         let user = x.Details["User"].getStr("N/A")
         let name = x.Details["Name"].getStr("N/A")

--- a/src/takajopkg/stackTasks.nim
+++ b/src/takajopkg/stackTasks.nim
@@ -36,7 +36,7 @@ method analyze*(self: StackTasksCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x, otherColumn=otherColumn)
 
 method resultOutput*(self: StackTasksCmd)=
-    outputResult(self.output, self.name, self.stack, self.header)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, self.header)
 
 proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ignoreSecurity: bool = false, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -45,7 +45,7 @@ proc stackTasks(level: string = "informational", ignoreSysmon: bool = false, ign
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "Tasks",
+                name: "Stack Tasks",
                 msg: StackTasksMsg,
                 ignoreSysmon: ignoreSysmon,
                 ignoreSecurity: ignoreSecurity)

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -12,6 +12,8 @@ const SYSTEM_ACCOUNTS = toHashSet([
     "IIS APPPOOL\\DefaultAppPool"
 ])
 
+const StackUsersMsg = "This command will stack the TgtUser (default) or SrcUser fields as well as show alert information"
+
 type
   StackUsersCmd* = ref object of AbstractCmd
     level* :string
@@ -46,5 +48,13 @@ method resultOutput*(self: StackUsersCmd) =
 
 proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
-    let cmd = StackUsersCmd(level:level, timeline:timeline, output:output, name:"Users", msg:"the TgtUser (default) or SrcUser fields as well as show alert information", sourceUsers:sourceUsers, filterSystemAccounts:filterSystemAccounts, filterComputerAccounts:filterComputerAccounts)
+    let cmd = StackUsersCmd(
+                level: level,
+                timeline: timeline,
+                output: output,
+                name: "Users",
+                msg: StackUsersMsg,
+                sourceUsers: sourceUsers,
+                filterSystemAccounts: filterSystemAccounts,
+                filterComputerAccounts: filterComputerAccounts)
     cmd.analyzeJSONLFile()

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -17,7 +17,6 @@ const StackUsersMsg = "This command will stack the TgtUser (default) or SrcUser 
 type
   StackUsersCmd* = ref object of AbstractCmd
     level* :string
-    header* = @[""]
     stack* = initTable[string, StackRecord]()
     sourceUsers:bool
     filterComputerAccounts:bool
@@ -44,7 +43,7 @@ method analyze*(self: StackUsersCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackUsersCmd) =
-    outputResult(self.output, self.name, self.stack, self.header, isMinColumns=true)
+    outputResult(self.output, self.name, self.stack, isMinColumns=true)
 
 proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -12,24 +12,41 @@ const SYSTEM_ACCOUNTS = toHashSet([
     "IIS APPPOOL\\DefaultAppPool"
 ])
 
-proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, level)
-    let totalLines = countJsonlAndStartMsg("Users", "the TgtUser (default) or SrcUser fields as well as show alert information", timeline)
-    let eventFilter = proc(x: HayabusaJson): bool = true
+type
+  StackUsersCmd* = ref object of AbstractCmd
+    level* :string
+    header* = @[""]
+    stack* = initTable[string, StackRecord]()
+    sourceUsers:bool
+    filterComputerAccounts:bool
+    filterSystemAccounts:bool
+
+method eventFilter*(self: StackUsersCmd, x: HayabusaJson):bool =
+    return true
+
+method eventProcess*(self: StackUsersCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         var stackKey = getJsonValue(x.Details, @["User"])
         if stackKey.len() == 0:
-            let key = if sourceUsers: "SrcUser" else: "TgtUser"
+            let key = if self.sourceUsers: "SrcUser" else: "TgtUser"
             stackKey = getJsonValue(x.Details, @[key])
-        if filterComputerAccounts and stackKey.endsWith("$"):
+        if self.filterComputerAccounts and stackKey.endsWith("$"):
             stackKey = ""
-        if filterSystemAccounts:
+        if self.filterSystemAccounts:
             for excludeAccount in SYSTEM_ACCOUNTS:
                 if cmpIgnoreCase(stackKey, excludeAccount) == 0:
                     stackKey = ""
                     continue
-        return (stackKey, @[])
-    let stack = processJSONL(eventFilter, getStackKey, totalLines, timeline, level)
-    outputResult(output, "User", stack, @[], isMinColumns=true)
+        return (stackKey, @[""])
+    let (stackKey, otherColumn) = getStackKey(x)
+    stackResult(stackKey, self.stack, self.level, x)
+
+method resultOutput*(self: StackUsersCmd) =
+    outputResult(self.output, self.name, self.stack, self.header, isMinColumns=true)
+
+proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, output: string = "", quiet: bool = false, timeline: string) =
+    let startTime = epochTime()
+    checkArgs(quiet, timeline, level)
+    let cmd = StackUsersCmd(level:level, timeline:timeline, output:output, name:"Users", msg:"the TgtUser (default) or SrcUser fields as well as show alert information", sourceUsers:sourceUsers, filterSystemAccounts:filterSystemAccounts, filterComputerAccounts:filterComputerAccounts)
+    cmd.analyzeJSONLFile()
     outputElapsedTime(startTime)

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -21,10 +21,10 @@ type
     filterComputerAccounts:bool
     filterSystemAccounts:bool
 
-method eventFilter*(self: StackUsersCmd, x: HayabusaJson):bool =
+method filter*(self: StackUsersCmd, x: HayabusaJson):bool =
     return true
 
-method eventProcess*(self: StackUsersCmd, x: HayabusaJson)=
+method analyze*(self: StackUsersCmd, x: HayabusaJson)=
     let getStackKey = proc(x: HayabusaJson): (string, seq[string]) =
         var stackKey = getJsonValue(x.Details, @["User"])
         if stackKey.len() == 0:

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -46,10 +46,11 @@ method analyze*(self: StackUsersCmd, x: HayabusaJson)=
 method resultOutput*(self: StackUsersCmd) =
     outputResult(self.output, self.name, self.stack, self.header, isMinColumns=true)
 
-proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, output: string = "", quiet: bool = false, timeline: string) =
+proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
     let cmd = StackUsersCmd(
                 level: level,
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name: "Users",

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -45,8 +45,6 @@ method resultOutput*(self: StackUsersCmd) =
     outputResult(self.output, self.name, self.stack, self.header, isMinColumns=true)
 
 proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, level)
     let cmd = StackUsersCmd(level:level, timeline:timeline, output:output, name:"Users", msg:"the TgtUser (default) or SrcUser fields as well as show alert information", sourceUsers:sourceUsers, filterSystemAccounts:filterSystemAccounts, filterComputerAccounts:filterComputerAccounts)
     cmd.analyzeJSONLFile()
-    outputElapsedTime(startTime)

--- a/src/takajopkg/stackUsers.nim
+++ b/src/takajopkg/stackUsers.nim
@@ -43,7 +43,7 @@ method analyze*(self: StackUsersCmd, x: HayabusaJson)=
     stackResult(stackKey, self.stack, self.level, x)
 
 method resultOutput*(self: StackUsersCmd) =
-    outputResult(self.output, self.name, self.stack, isMinColumns=true)
+    outputResult(self.output, self.name.replace("Stack ", ""), self.stack, isMinColumns=true)
 
 proc stackUsers(level: string = "informational", sourceUsers: bool = false, filterComputerAccounts: bool = true, filterSystemAccounts: bool = true, skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, level)
@@ -52,7 +52,7 @@ proc stackUsers(level: string = "informational", sourceUsers: bool = false, filt
                 skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
-                name: "Users",
+                name: "Stack Users",
                 msg: StackUsersMsg,
                 sourceUsers: sourceUsers,
                 filterSystemAccounts: filterSystemAccounts,

--- a/src/takajopkg/stackUtil.nim
+++ b/src/takajopkg/stackUtil.nim
@@ -63,6 +63,8 @@ proc buildCSVRecord(x: StackRecord, isMinColumns:bool = false): seq[string] =
   return concat(@[intToStr(x.count), x.channel, x.eid], x.otherColumn, @[levelsStr, ruleTitlesStr])
 
 proc stackResult*(key:string, stack: var Table[string, StackRecord], minLevel:string, jsonLine:HayabusaJson, otherColumn:seq[string] = @[]) =
+    if key.len() == 0 or key == "-" or key == "Unknown" or key == "n/a":
+        return
     let level = jsonLine.Level
     if not isMinLevel(level, minLevel):
         return

--- a/src/takajopkg/stackUtil.nim
+++ b/src/takajopkg/stackUtil.nim
@@ -112,26 +112,3 @@ proc outputResult*(output:string, culumnName: string, stack: Table[string, Stack
         close(outputFile)
         echo ""
         echo "Saved file: " & output & " (" & formatFileSize(outputFileSize) & ")"
-
-proc processJSONL*(eventFilter: proc (x: HayabusaJson): bool,
-                   getStackKey: proc (x: HayabusaJson): (string, seq[string]),
-                   totalLines:int, timeline:string, level:string): Table[string, StackRecord] =
-    var bar: SuruBar = initSuruBar()
-    var stack = initTable[string, StackRecord]()
-    bar[0].total = totalLines
-    bar.setup()
-    # Loop through JSON lines
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        if eventFilter(jsonLine):
-            let (stackKey, otherColumn) = getStackKey(jsonLine)
-            if stackKey.len() == 0 or stackKey == "-" or stackKey == "Unknown" or stackKey == "n/a":
-                continue
-            stackResult(stackKey, stack, level, jsonLine, otherColumn)
-    bar.finish()
-    return stack

--- a/src/takajopkg/stackUtil.nim
+++ b/src/takajopkg/stackUtil.nim
@@ -3,10 +3,8 @@ import json
 import nancy
 import takajoTerminal
 import hayabusaJson
-import suru
 import std/algorithm
 import std/enumerate
-import std/options
 import std/sequtils
 import std/strutils
 import std/tables

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -13,7 +13,7 @@ type
     output*: string
 
 method filter*(self: AbstractCmd, x: HayabusaJson):bool {.base.} =
-  raise newException(ValueError, "filter(AbstractCmd) is not implemented")
+  return true
 
 method analyze*(self: AbstractCmd, x: HayabusaJson) {.base.} =
   raise newException(ValueError, "analyze(AbstractCmd) is not implemented")

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -12,11 +12,11 @@ type
     msg*: string
     output*: string
 
-method eventFilter*(self: AbstractCmd, x: HayabusaJson):bool {.base.} =
-  raise newException(ValueError, "eventFilter is not implemented")
+method filter*(self: AbstractCmd, x: HayabusaJson):bool {.base.} =
+  raise newException(ValueError, "filterHayabusaJSON is not implemented")
 
-method eventProcess*(self: AbstractCmd, x: HayabusaJson){.base.}=
-  raise newException(ValueError, "eventProcess is not implemented")
+method analyze*(self: AbstractCmd, x: HayabusaJson) {.base.} =
+  raise newException(ValueError, "analyzeHayabusaJSON is not implemented")
 
 method resultOutput*(self: AbstractCmd) {.base.} =
   raise newException(ValueError, "resultOutput is not implemented")
@@ -40,8 +40,8 @@ proc analyzeJSONLFile*(self: AbstractCmd) =
         if jsonLineOpt.isNone:
             continue
         let jsonLine:HayabusaJson = jsonLineOpt.get()
-        if self.eventFilter(jsonLine):
-            self.eventProcess(jsonLine)
+        if self.filter(jsonLine):
+            self.analyze(jsonLine)
     if not skipProgressBar:
       bar.finish()
     self.resultOutput()
@@ -67,8 +67,8 @@ proc analyzeJSONLFileWithMultipleCmd*(baseCmd:AbstractCmd , cmds: seq[AbstractCm
             continue
         let jsonLine:HayabusaJson = jsonLineOpt.get()
         for cmd in cmds:
-            if cmd.eventFilter(jsonLine):
-                cmd.eventProcess(jsonLine)
+            if cmd.filter(jsonLine):
+                cmd.analyze(jsonLine)
     if not skipProgressBar:
       bar.finish()
 

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -40,8 +40,8 @@ proc analyzeJSONLFile*(self: AbstractCmd) =
         if jsonLineOpt.isNone:
             continue
         let jsonLine:HayabusaJson = jsonLineOpt.get()
-        if self.eventFilter(x):
-            self.eventProcess(x)
+        if self.eventFilter(jsonLine):
+            self.eventProcess(jsonLine)
     if not skipProgressBar:
       bar.finish()
     self.resultOutput()

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -1,0 +1,48 @@
+import general
+import hayabusaJson
+import std/options
+import suru
+
+type
+  AbstractCmd* = ref object of RootObj
+    timeline*: string
+    skipProgressBar*: bool
+    name*: string
+    msg*: string
+    output*: string
+
+method eventFilter*(self: AbstractCmd, x: HayabusaJson):bool {.base.} =
+  raise newException(ValueError, "eventFilter is not implemented")
+
+method eventProcess*(self: AbstractCmd, x: HayabusaJson){.base.}=
+  raise newException(ValueError, "eventProcess is not implemented")
+
+method resultOutput*(self: AbstractCmd) {.base.} =
+  raise newException(ValueError, "resultOutput is not implemented")
+
+proc analyzeJSONLLine*(self: AbstractCmd, x: HayabusaJson) =
+    if self.eventFilter(x):
+        self.eventProcess(x)
+
+proc analyzeJSONLFile*(self: AbstractCmd) =
+    var bar: SuruBar
+    let skipProgressBar = self.skipProgressBar
+    let timeline = self.timeline
+
+    if not skipProgressBar:
+        bar = initSuruBar()
+        bar[0].total = countJsonlAndStartMsg(self.name, self.msg, timeline)
+        bar.setup()
+
+    for line in lines(timeline):
+        if not skipProgressBar:
+            inc bar
+            bar.update(1000000000)
+        let jsonLineOpt = parseLine(line)
+        if jsonLineOpt.isNone:
+            continue
+        let jsonLine:HayabusaJson = jsonLineOpt.get()
+        self.analyzeJSONLLine(jsonLine)
+    if not skipProgressBar:
+      bar.finish()
+    self.resultOutput()

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -13,13 +13,13 @@ type
     output*: string
 
 method filter*(self: AbstractCmd, x: HayabusaJson):bool {.base.} =
-  raise newException(ValueError, "filterHayabusaJSON is not implemented")
+  raise newException(ValueError, "filter(AbstractCmd) is not implemented")
 
 method analyze*(self: AbstractCmd, x: HayabusaJson) {.base.} =
-  raise newException(ValueError, "analyzeHayabusaJSON is not implemented")
+  raise newException(ValueError, "analyze(AbstractCmd) is not implemented")
 
 method resultOutput*(self: AbstractCmd) {.base.} =
-  raise newException(ValueError, "resultOutput is not implemented")
+  raise newException(ValueError, "resultOutput(AbstractCmd) is not implemented")
 
 proc analyzeJSONLFile*(self: AbstractCmd) =
     let startTime = epochTime()

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -2,6 +2,7 @@ import general
 import hayabusaJson
 import std/options
 import suru
+import times
 
 type
   AbstractCmd* = ref object of RootObj
@@ -25,6 +26,7 @@ proc analyzeJSONLLine*(self: AbstractCmd, x: HayabusaJson) =
         self.eventProcess(x)
 
 proc analyzeJSONLFile*(self: AbstractCmd) =
+    let startTime = epochTime()
     var bar: SuruBar
     let skipProgressBar = self.skipProgressBar
     let timeline = self.timeline
@@ -46,3 +48,4 @@ proc analyzeJSONLFile*(self: AbstractCmd) =
     if not skipProgressBar:
       bar.finish()
     self.resultOutput()
+    outputElapsedTime(startTime)

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -21,10 +21,6 @@ method eventProcess*(self: AbstractCmd, x: HayabusaJson){.base.}=
 method resultOutput*(self: AbstractCmd) {.base.} =
   raise newException(ValueError, "resultOutput is not implemented")
 
-proc analyzeJSONLLine*(self: AbstractCmd, x: HayabusaJson) =
-    if self.eventFilter(x):
-        self.eventProcess(x)
-
 proc analyzeJSONLFile*(self: AbstractCmd) =
     let startTime = epochTime()
     var bar: SuruBar
@@ -44,7 +40,8 @@ proc analyzeJSONLFile*(self: AbstractCmd) =
         if jsonLineOpt.isNone:
             continue
         let jsonLine:HayabusaJson = jsonLineOpt.get()
-        self.analyzeJSONLLine(jsonLine)
+        if self.eventFilter(x):
+            self.eventProcess(x)
     if not skipProgressBar:
       bar.finish()
     self.resultOutput()

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -67,8 +67,11 @@ proc analyzeJSONLFileWithMultipleCmd*(baseCmd:AbstractCmd , cmds: seq[AbstractCm
             continue
         let jsonLine:HayabusaJson = jsonLineOpt.get()
         for cmd in cmds:
-            if cmd.filter(jsonLine):
-                cmd.analyze(jsonLine)
+            try:
+                if cmd.filter(jsonLine):
+                    cmd.analyze(jsonLine)
+            except CatchableError:
+                continue
     if not skipProgressBar:
       bar.finish()
 

--- a/src/takajopkg/timelineLogon.nim
+++ b/src/takajopkg/timelineLogon.nim
@@ -6,208 +6,182 @@ const TimelineLogonMsg =
     Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.
     """
 
+type
+  TimelineLogonCmd* = ref object of AbstractCmd
+      seqOfResultsTables*: seq[TableRef[string, string]] # Sequences are immutable so need to create a sequence of pointers to tables so we can update ["ElapsedTime"]
+      seqOfLogoffEventTables*: seq[Table[string, string]] # This sequence can be immutable
+      logoffEvents*: Table[string, string] = initTable[string, string]()
+      adminLogonEvents*: Table[string, string] = initTable[string, string]()
+      EID_4624_count* = 0 # Successful logon
+      EID_4625_count* = 0 # Failed logon
+      EID_4634_count* = 0 # Logoff
+      EID_4647_count* = 0 # User initiated logoff
+      EID_4648_count* = 0 # Explicit logon
+      EID_4672_count* = 0 # Admin logon
+      calculateElapsedTime* :bool
+      outputLogoffEvents*: bool
+      outputAdminLogonEvents*: bool
 
+method filter*(self: TimelineLogonCmd, x: HayabusaJson):bool =
+    return x.EventId == 4624 or x.EventId == 4625 or x.EventId == 4634 or x.EventId == 4647 or x.EventId == 4648 or x.EventId == 4672
 
-proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogoffEvents: bool = false, outputAdminLogonEvents: bool = false, quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, "informational")
+method analyze*(self: TimelineLogonCmd, x: HayabusaJson) =
+    let ruleTitle = x.RuleTitle
+    let jsonLine = x
+    #EID 4624 Successful Logon
+    if isEID_4624(ruleTitle) == true:
+        inc self.EID_4624_count
+        var singleResultTable = newTable[string, string]()
+        singleResultTable["Event"] = "Successful Logon"
+        singleResultTable["Timestamp"] = jsonLine.Timestamp
+        singleResultTable["Channel"] = jsonLine.Channel
+        singleResultTable["EventID"] = "4624"
+        let details = jsonLine.Details
+        let extraFieldInfo = jsonLine.ExtraFieldInfo
+        let logonType = details.extractStr("Type") # Will be Int if field mapping is turned off
+        singleResultTable["Type"] = logonType # Needs to be logonNumberToString(logonType) if data field mapping is turned off. TODO
+        singleResultTable["Auth"] = extraFieldInfo.extractStr("AuthenticationPackageName")
+        singleResultTable["TargetComputer"] = jsonLine.Computer
+        singleResultTable["TargetUser"] = details.extractStr("TgtUser")
+        let impersonationLevel = extraFieldInfo.extractStr("ImpersonationLevel")
+        singleResultTable["Impersonation"] = impersonationLevelIdToName(impersonationLevel)
+        singleResultTable["SourceIP"] = details.extractStr("SrcComp")
+        singleResultTable["Process"] = details.extractStr("LogonProcessName")
+        singleResultTable["LID"] = details.extractStr("LID")
+        singleResultTable["LGUID"] = extraFieldInfo.extractStr("LogonGuid")
+        singleResultTable["SourceComputer"] = details.extractStr("SrcIP")
+        let elevatedToken = extraFieldInfo.extractStr("ElevatedToken")
+        singleResultTable["ElevatedToken"] = elevatedTokenIdToName(elevatedToken)
+        singleResultTable["TargetUserSID"] = extraFieldInfo.extractStr("TargetUserSid")
+        singleResultTable["TargetDomainName"] = extraFieldInfo.extractStr("TargetDomainName")
+        singleResultTable["TargetLinkedLID"] = extraFieldInfo.extractStr("TargetLinkedLogonId")
+        singleResultTable["LogoffTime"] = ""
+        singleResultTable["ElapsedTime"] = ""
+        singleResultTable["AdminLogon"] = ""
+        self.seqOfResultsTables.add(singleResultTable)
 
-    echo "Started the Timeline Logon command"
-    echo ""
-    echo "This command creates a CSV timeline of logon events."
-    echo "Elapsed time for successful logons are calculated by default but can be disabled with -c=false."
-    echo "Logoff events can be outputted on separate lines with -l, --outputLogoffEvents."
-    echo "Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents."
-    echo ""
-    echo ""
+    #EID 4625 Failed Logon
+    if isEID_4625(ruleTitle) == true:
+        inc self.EID_4625_count
+        var singleResultTable = newTable[string, string]()
+        singleResultTable["Event"] = "Failed Logon"
+        singleResultTable["Timestamp"] = jsonLine.Timestamp
+        singleResultTable["Channel"] = jsonLine.Channel
+        singleResultTable["EventID"] = "4625"
+        let details = jsonLine.Details
+        let extraFieldInfo = jsonLine.ExtraFieldInfo
+        let logonType = details.extractStr("Type")
+        singleResultTable["Type"] = logonType # Needs to be logonNumberToString(logonType) if data field mapping is turned off. TODO
+        singleResultTable["Auth"] = details.extractStr("AuthPkg")
+        singleResultTable["TargetComputer"] = jsonLine.Computer
+        singleResultTable["TargetUser"] = details.extractStr("TgtUser")
+        singleResultTable["SourceIP"] = details.extractStr("SrcIP")
+        singleResultTable["Process"] = details.extractStr("Proc")
+        singleResultTable["SourceComputer"] = details.extractStr("SrcComp")
+        singleResultTable["TargetUserSID"] = extraFieldInfo.extractStr("TargetUserSid") # Don't output as it is always S-1-0-0
+        singleResultTable["TargetDomainName"] = extraFieldInfo.extractStr("TargetDomainName")
+        singleResultTable["FailureReason"] = logonFailureReason(extraFieldInfo.extractStr("SubStatus"))
+        self.seqOfResultsTables.add(singleResultTable)
 
-    let totalLines = countLinesInTimeline(timeline)
-
-    echo "Creating a logon timeline. Please wait."
-    echo ""
-
-    var
-        seqOfResultsTables: seq[TableRef[string, string]] # Sequences are immutable so need to create a sequence of pointers to tables so we can update ["ElapsedTime"]
-        seqOfLogoffEventTables: seq[Table[string, string]] # This sequence can be immutable
-        logoffEvents: Table[string, string] = initTable[string, string]()
-        adminLogonEvents: Table[string, string] = initTable[string, string]()
-        EID_4624_count = 0 # Successful logon
-        EID_4625_count = 0 # Failed logon
-        EID_4634_count = 0 # Logoff
-        EID_4647_count = 0 # User initiated logoff
-        EID_4648_count = 0 # Explicit logon
-        EID_4672_count = 0 # Admin logon
-        bar: SuruBar = initSuruBar()
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000)
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        let ruleTitle = jsonLine.RuleTitle
-
-        #EID 4624 Successful Logon
-        if isEID_4624(ruleTitle) == true:
-            inc EID_4624_count
+    #EID 4634 Logoff
+    if ruleTitle == "Logoff":
+        inc self.EID_4634_count
+        # If we want to calculate ElapsedTime
+        if self.calculateElapsedTime:
+            # Create the key in the format of LID:Computer:User with a value of the timestamp
+            let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["User"].getStr()
+            let logoffTime = jsonLine.Timestamp
+            self.logoffEvents[key] = logoffTime
+        if self.outputLogoffEvents:
             var singleResultTable = newTable[string, string]()
-            singleResultTable["Event"] = "Successful Logon"
+            singleResultTable["Event"] = "User Initiated Logoff"
             singleResultTable["Timestamp"] = jsonLine.Timestamp
             singleResultTable["Channel"] = jsonLine.Channel
-            singleResultTable["EventID"] = "4624"
-            let details = jsonLine.Details
-            let extraFieldInfo = jsonLine.ExtraFieldInfo
-            let logonType = details.extractStr("Type") # Will be Int if field mapping is turned off
-            singleResultTable["Type"] = logonType # Needs to be logonNumberToString(logonType) if data field mapping is turned off. TODO
-            singleResultTable["Auth"] = extraFieldInfo.extractStr("AuthenticationPackageName")
             singleResultTable["TargetComputer"] = jsonLine.Computer
-            singleResultTable["TargetUser"] = details.extractStr("TgtUser")
-            let impersonationLevel = extraFieldInfo.extractStr("ImpersonationLevel")
-            singleResultTable["Impersonation"] = impersonationLevelIdToName(impersonationLevel)
-            singleResultTable["SourceIP"] = details.extractStr("SrcComp")
-            singleResultTable["Process"] = details.extractStr("LogonProcessName")
+            singleResultTable["EventID"] = "4634"
+            let details = jsonLine.Details
+            singleResultTable["TargetUser"] = details.extractStr("User")
             singleResultTable["LID"] = details.extractStr("LID")
-            singleResultTable["LGUID"] = extraFieldInfo.extractStr("LogonGuid")
-            singleResultTable["SourceComputer"] = details.extractStr("SrcIP")
-            let elevatedToken = extraFieldInfo.extractStr("ElevatedToken")
-            singleResultTable["ElevatedToken"] = elevatedTokenIdToName(elevatedToken)
-            singleResultTable["TargetUserSID"] = extraFieldInfo.extractStr("TargetUserSid")
-            singleResultTable["TargetDomainName"] = extraFieldInfo.extractStr("TargetDomainName")
-            singleResultTable["TargetLinkedLID"] = extraFieldInfo.extractStr("TargetLinkedLogonId")
-            singleResultTable["LogoffTime"] = ""
-            singleResultTable["ElapsedTime"] = ""
-            singleResultTable["AdminLogon"] = ""
+            self.seqOfResultsTables.add(singleResultTable)
 
-            seqOfResultsTables.add(singleResultTable)
-
-        #EID 4625 Failed Logon
-        if isEID_4625(ruleTitle) == true:
-            inc EID_4625_count
+    #EID 4647 User Initiated Logoff
+    if ruleTitle == "Logoff (User Initiated)":
+        inc self.EID_4647_count
+        # If we want to calculate ElapsedTime
+        if self.calculateElapsedTime:
+            # Create the key in the format of LID:Computer:User with a value of the timestamp
+            let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["User"].getStr()
+            let logoffTime = jsonLine.Timestamp
+            self.logoffEvents[key] = logoffTime
+        if self.outputLogoffEvents:
             var singleResultTable = newTable[string, string]()
-            singleResultTable["Event"] = "Failed Logon"
+            singleResultTable["Event"] = "User Initiated Logoff"
             singleResultTable["Timestamp"] = jsonLine.Timestamp
             singleResultTable["Channel"] = jsonLine.Channel
-            singleResultTable["EventID"] = "4625"
-            let details = jsonLine.Details
-            let extraFieldInfo = jsonLine.ExtraFieldInfo
-            let logonType = details.extractStr("Type")
-            singleResultTable["Type"] = logonType # Needs to be logonNumberToString(logonType) if data field mapping is turned off. TODO
-            singleResultTable["Auth"] = details.extractStr("AuthPkg")
             singleResultTable["TargetComputer"] = jsonLine.Computer
-            singleResultTable["TargetUser"] = details.extractStr("TgtUser")
-            singleResultTable["SourceIP"] = details.extractStr("SrcIP")
-            singleResultTable["Process"] = details.extractStr("Proc")
-            singleResultTable["SourceComputer"] = details.extractStr("SrcComp")
-            singleResultTable["TargetUserSID"] = extraFieldInfo.extractStr("TargetUserSid") # Don't output as it is always S-1-0-0
-            singleResultTable["TargetDomainName"] = extraFieldInfo.extractStr("TargetDomainName")
-            singleResultTable["FailureReason"] = logonFailureReason(extraFieldInfo.extractStr("SubStatus"))
+            singleResultTable["EventID"] = "4647"
+            let details = jsonLine.Details
+            singleResultTable["TargetUser"] = details.extractStr("User")
+            singleResultTable["LID"] = details.extractStr("LID")
+            self.seqOfResultsTables.add(singleResultTable)
 
-            seqOfResultsTables.add(singleResultTable)
+    #EID 4648 Explicit Logon
+    if ruleTitle == "Explicit Logon" or ruleTitle == "Explicit Logon (Suspicious Process)":
+        inc self.EID_4648_count
+        var singleResultTable = newTable[string, string]()
+        singleResultTable["Event"] = "Explicit Logon"
+        singleResultTable["Timestamp"] = jsonLine.Timestamp
+        singleResultTable["Channel"] = jsonLine.Channel
+        singleResultTable["EventID"] = "4648"
+        let details = jsonLine.Details
+        let extraFieldInfo = jsonLine.ExtraFieldInfo
+        singleResultTable["TargetComputer"] = details.extractStr("TgtSvr")
+        singleResultTable["TargetUser"] = details.extractStr("TgtUser")
+        singleResultTable["SourceUser"] = details.extractStr("SrcUser")
+        singleResultTable["SourceIP"] = details.extractStr("SrcIP")
+        singleResultTable["Process"] = details.extractStr("Proc")
+        singleResultTable["LID"] = details.extractStr("LID")
+        singleResultTable["LGUID"] = extraFieldInfo.extractStr("LogonGuid")
+        singleResultTable["SourceComputer"] = jsonLine.Computer # 4648 is a little different in that the log is saved on the source computer so Computer will be the source.
+        self.seqOfResultsTables.add(singleResultTable)
 
-        #EID 4634 Logoff
-        if ruleTitle == "Logoff":
-            inc EID_4634_count
-            # If we want to calculate ElapsedTime
-            if calculateElapsedTime == true:
-                # Create the key in the format of LID:Computer:User with a value of the timestamp
-                let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["User"].getStr()
-                let logoffTime = jsonLine.Timestamp
-                logoffEvents[key] = logoffTime
-            if outputLogoffEvents == true:
-                var singleResultTable = newTable[string, string]()
-                singleResultTable["Event"] = "User Initiated Logoff"
-                singleResultTable["Timestamp"] = jsonLine.Timestamp
-                singleResultTable["Channel"] = jsonLine.Channel
-                singleResultTable["TargetComputer"] = jsonLine.Computer
-                singleResultTable["EventID"] = "4634"
-                let details = jsonLine.Details
-                singleResultTable["TargetUser"] = details.extractStr("User")
-                singleResultTable["LID"] = details.extractStr("LID")
-                seqOfResultsTables.add(singleResultTable)
-
-        #EID 4647 User Initiated Logoff
-        if ruleTitle == "Logoff (User Initiated)":
-            inc EID_4647_count
-            # If we want to calculate ElapsedTime
-            if calculateElapsedTime == true:
-                # Create the key in the format of LID:Computer:User with a value of the timestamp
-                let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["User"].getStr()
-                let logoffTime = jsonLine.Timestamp
-                logoffEvents[key] = logoffTime
-            if outputLogoffEvents == true:
-                var singleResultTable = newTable[string, string]()
-                singleResultTable["Event"] = "User Initiated Logoff"
-                singleResultTable["Timestamp"] = jsonLine.Timestamp
-                singleResultTable["Channel"] = jsonLine.Channel
-                singleResultTable["TargetComputer"] = jsonLine.Computer
-                singleResultTable["EventID"] = "4647"
-                let details = jsonLine.Details
-                singleResultTable["TargetUser"] = details.extractStr("User")
-                singleResultTable["LID"] = details.extractStr("LID")
-                seqOfResultsTables.add(singleResultTable)
-
-        #EID 4648 Explicit Logon
-        if ruleTitle == "Explicit Logon" or ruleTitle == "Explicit Logon (Suspicious Process)":
-            inc EID_4648_count
+    # EID 4672 Admin Logon
+    # When someone logs in with administrator level privileges, there will be two logon sessions created. One for a lower privileged user and one with admin privileges.
+    # I am just going to add "Yes" to the "AdminLogon" column in the 4624 (Successful logon) event to save space.
+    # The timing will be very close to the 4624 log so I am checking if the Computer, LID and TgtUser are the same and then if the two events happened within 10 seconds.
+    if ruleTitle == "Admin Logon":
+        inc self.EID_4672_count
+        let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["TgtUser"].getStr()
+        let adminLogonTime = jsonLine.Timestamp
+        self.adminLogonEvents[key] = adminLogonTime
+        if self.outputAdminLogonEvents:
             var singleResultTable = newTable[string, string]()
-            singleResultTable["Event"] = "Explicit Logon"
+            singleResultTable["Event"] = "Admin Logon"
             singleResultTable["Timestamp"] = jsonLine.Timestamp
             singleResultTable["Channel"] = jsonLine.Channel
-            singleResultTable["EventID"] = "4648"
+            singleResultTable["EventID"] = "4672"
+            singleResultTable["TargetComputer"] = jsonLine.Computer
+            let eventId = jsonLine.EventID
             let details = jsonLine.Details
-            let extraFieldInfo = jsonLine.ExtraFieldInfo
-            singleResultTable["TargetComputer"] = details.extractStr("TgtSvr")
             singleResultTable["TargetUser"] = details.extractStr("TgtUser")
-            singleResultTable["SourceUser"] = details.extractStr("SrcUser")
-            singleResultTable["SourceIP"] = details.extractStr("SrcIP")
-            singleResultTable["Process"] = details.extractStr("Proc")
             singleResultTable["LID"] = details.extractStr("LID")
-            singleResultTable["LGUID"] = extraFieldInfo.extractStr("LogonGuid")
-            singleResultTable["SourceComputer"] = jsonLine.Computer # 4648 is a little different in that the log is saved on the source computer so Computer will be the source.
-            seqOfResultsTables.add(singleResultTable)
+            self.seqOfResultsTables.add(singleResultTable)
 
-        # EID 4672 Admin Logon
-        # When someone logs in with administrator level privileges, there will be two logon sessions created. One for a lower privileged user and one with admin privileges.
-        # I am just going to add "Yes" to the "AdminLogon" column in the 4624 (Successful logon) event to save space.
-        # The timing will be very close to the 4624 log so I am checking if the Computer, LID and TgtUser are the same and then if the two events happened within 10 seconds.
-        if ruleTitle == "Admin Logon":
-            inc EID_4672_count
-            let key = jsonLine.Details["LID"].getStr() & ":" & jsonLine.Computer & ":" & jsonLine.Details["TgtUser"].getStr()
-            let adminLogonTime = jsonLine.Timestamp
-            adminLogonEvents[key] = adminLogonTime
-            if outputAdminLogonEvents == true:
-                var singleResultTable = newTable[string, string]()
-                singleResultTable["Event"] = "Admin Logon"
-                singleResultTable["Timestamp"] = jsonLine.Timestamp
-                singleResultTable["Channel"] = jsonLine.Channel
-                singleResultTable["EventID"] = "4672"
-                singleResultTable["TargetComputer"] = jsonLine.Computer
-                let eventId = jsonLine.EventID
-                let details = jsonLine.Details
-                singleResultTable["TargetUser"] = details.extractStr("TgtUser")
-                singleResultTable["LID"] = details.extractStr("LID")
-                seqOfResultsTables.add(singleResultTable)
-
-    bar.finish()
-
+method resultOutput*(self: TimelineLogonCmd) =
     echo ""
     echo "Calculating logon elapsed time. Please wait."
     echo ""
 
     # Calculating the logon elapsed time (default)
-    if calculateElapsedTime == true:
-        for tableOfResults in seqOfResultsTables:
+    if self.calculateElapsedTime:
+        for tableOfResults in self.seqOfResultsTables:
             if tableOfResults["EventID"] == "4624":
                 var logoffTime = ""
                 var logonTime = tableOfResults["Timestamp"]
 
                 let key = tableOfResults["LID"] & ":" & tableOfResults["TargetComputer"] & ":" & tableOfResults["TargetUser"]
-                if logoffEvents.hasKey(key):
-                    logoffTime = logoffEvents[key]
+                if self.logoffEvents.hasKey(key):
+                    logoffTime = self.logoffEvents[key]
                     tableOfResults[]["LogoffTime"] = logoffTime
                     logonTime = logonTime[0 ..< logonTime.len - 7]
                     logoffTime = logoffTime[0 ..< logofftime.len - 7]
@@ -219,14 +193,14 @@ proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogo
                     logoffTime = "n/a"
 
     # Find admin logons
-    for tableOfResults in seqOfResultsTables:
+    for tableOfResults in self.seqOfResultsTables:
         if tableOfResults["EventID"] == "4624":
             var logonTime = tableOfResults["Timestamp"]
             logonTime = logonTime[0 ..< logonTime.len - 7] # Remove the timezone
             #echo "4624 logon time: " & logonTime
             let key = tableOfResults["LID"] & ":" & tableOfResults["TargetComputer"] & ":" & tableOfResults["TargetUser"]
-            if adminLogonEvents.hasKey(key):
-                var adminLogonTime = adminLogonEvents[key]
+            if self.adminLogonEvents.hasKey(key):
+                var adminLogonTime = self.adminLogonEvents[key]
                 adminLogonTime = adminLogonTime[0 ..< adminLogonTime.len - 7] # Remove the timezone
                 let parsed_4624_logonTime = parse(logonTime, "yyyy-MM-dd HH:mm:ss'.'fff")
                 let parsed_4672_logonTime = parse(adminLogonTime, "yyyy-MM-dd HH:mm:ss'.'fff")
@@ -236,16 +210,16 @@ proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogo
                     tableOfResults[]["AdminLogon"] = "Yes"
 
     echo "Found logon events:"
-    echo "EID 4624 (Successful Logon): ", intToStr(EID_4624_count).insertSep(',')
-    echo "EID 4625 (Failed Logon): ", intToStr(EID_4625_count).insertSep(',')
-    echo "EID 4634 (Logoff): ", intToStr(EID_4634_count).insertSep(',')
-    echo "EID 4647 (User Initiated Logoff): ", intToStr(EID_4647_count).insertSep(',')
-    echo "EID 4648 (Explicit Logon): ", intToStr(EID_4648_count).insertSep(',')
-    echo "EID 4672 (Admin Logon): ", intToStr(EID_4672_count).insertSep(',')
+    echo "EID 4624 (Successful Logon): ", intToStr(self.EID_4624_count).insertSep(',')
+    echo "EID 4625 (Failed Logon): ", intToStr(self.EID_4625_count).insertSep(',')
+    echo "EID 4634 (Logoff): ", intToStr(self.EID_4634_count).insertSep(',')
+    echo "EID 4647 (User Initiated Logoff): ", intToStr(self.EID_4647_count).insertSep(',')
+    echo "EID 4648 (Explicit Logon): ", intToStr(self.EID_4648_count).insertSep(',')
+    echo "EID 4672 (Admin Logon): ", intToStr(self.EID_4672_count).insertSep(',')
     echo ""
 
     # Save results
-    var outputFile = open(output, fmWrite)
+    var outputFile = open(self.output, fmWrite)
     let header = ["Timestamp", "Channel", "EventID", "Event", "LogoffTime", "ElapsedTime", "FailureReason", "TargetComputer", "TargetUser", "AdminLogon", "SourceComputer", "SourceUser", "SourceIP", "Type", "Impersonation", "ElevatedToken", "Auth", "Process", "LID", "LGUID", "TargetUserSID", "TargetDomainName", "TargetLinkedLID"]
 
     ## Write CSV header
@@ -254,16 +228,28 @@ proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogo
     outputFile.write("\p")
 
     ## Write contents
-    for table in seqOfResultsTables:
+    for table in self.seqOfResultsTables:
         for key in header:
             if table.hasKey(key):
                 outputFile.write(escapeCsvField(table[key]) & ",")
             else:
                 outputFile.write(",")
         outputFile.write("\p")
-    let fileSize = getFileSize(output)
+    let fileSize = getFileSize(self.output)
     outputFile.close()
 
-    echo "Saved results to " & output & " (" & formatFileSize(fileSize) & ")"
+    echo "Saved results to " & self.output & " (" & formatFileSize(fileSize) & ")"
     echo ""
-    outputElapsedTime(startTime)
+
+proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogoffEvents: bool = false, outputAdminLogonEvents: bool = false, skipProgressBar:bool = false, quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, "informational")
+    let cmd = TimelineLogonCmd(
+                skipProgressBar: skipProgressBar,
+                timeline: timeline,
+                output: output,
+                name:"Timeline Logons",
+                msg: TimelineLogonMsg,
+                calculateElapsedTime:calculateElapsedTime,
+                outputLogoffEvents: outputLogoffEvents,
+                outputAdminLogonEvents: outputAdminLogonEvents)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/timelineLogon.nim
+++ b/src/takajopkg/timelineLogon.nim
@@ -3,8 +3,7 @@ const TimelineLogonMsg =
 This command creates a CSV timeline of logon events.
 Elapsed time for successful logons are calculated by default but can be disabled with -c=false.
 Logoff events can be outputted on separate lines with -l, --outputLogoffEvents.
-Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.
-    """
+Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents."""
 
 type
   TimelineLogonCmd* = ref object of AbstractCmd

--- a/src/takajopkg/timelineLogon.nim
+++ b/src/takajopkg/timelineLogon.nim
@@ -1,9 +1,9 @@
 const TimelineLogonMsg =
     """
-    This command creates a CSV timeline of logon events.
-    Elapsed time for successful logons are calculated by default but can be disabled with -c=false.
-    Logoff events can be outputted on separate lines with -l, --outputLogoffEvents.
-    Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.
+This command creates a CSV timeline of logon events.
+Elapsed time for successful logons are calculated by default but can be disabled with -c=false.
+Logoff events can be outputted on separate lines with -l, --outputLogoffEvents.
+Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.
     """
 
 type

--- a/src/takajopkg/timelineLogon.nim
+++ b/src/takajopkg/timelineLogon.nim
@@ -1,3 +1,13 @@
+const TimelineLogonMsg =
+    """
+    This command creates a CSV timeline of logon events.
+    Elapsed time for successful logons are calculated by default but can be disabled with -c=false.
+    Logoff events can be outputted on separate lines with -l, --outputLogoffEvents.
+    Admin logon events can be outputted on separate lines with -a, --outputAdminLogonEvents.
+    """
+
+
+
 proc timelineLogon(calculateElapsedTime: bool = true, output: string, outputLogoffEvents: bool = false, outputAdminLogonEvents: bool = false, quiet: bool = false, timeline: string) =
     let startTime = epochTime()
     checkArgs(quiet, timeline, "informational")

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -91,9 +91,10 @@ method resultOutput*(self: TimelinePartitionDiagnosticCmd) =
         table.echoTableSepsWithStyled(seps = boxSeps)
         echo ""
 
-proc timelinePartitionDiagnostic(output: string = "", quiet: bool = false, timeline: string) =
+proc timelinePartitionDiagnostic(skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = TimelinePartitionDiagnosticCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"Timeline PatitionDiagnostc",

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -1,7 +1,7 @@
 const TimelinePartitionDiagnosticMsg =
     """
-    Started the Timeline partition diagnostic command
-    This command will create a CSV timeline of partition diagnostic.
+Started the Timeline partition diagnostic command
+This command will create a CSV timeline of partition diagnostic.
     """
 
 type

--- a/src/takajopkg/timelinePartitionDiagnostic.nim
+++ b/src/takajopkg/timelinePartitionDiagnostic.nim
@@ -1,8 +1,4 @@
-const TimelinePartitionDiagnosticMsg =
-    """
-Started the Timeline partition diagnostic command
-This command will create a CSV timeline of partition diagnostic.
-    """
+const TimelinePartitionDiagnosticMsg = "This command will create a CSV timeline of partition diagnostic."
 
 type
   TimelinePartitionDiagnosticCmd* = ref object of AbstractCmd

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -210,9 +210,10 @@ method resultOutput*(self: TimelineSuspiciousProcessesCmd)=
     echo "Suspicious processes in Sysmon 1 process creation events: " & intToStr(self.suspicousProcessCount_Sysmon_1).insertSep(',')
     echo ""
 
-proc timelineSuspiciousProcesses(level: string = "high", output: string = "", quiet: bool = false, timeline: string) =
+proc timelineSuspiciousProcesses(level: string = "high", skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = TimelineSuspiciousProcessesCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 level: level,

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -2,8 +2,7 @@ const TimelineSuspiciousProcessesMsg =
   """
 This command will create a CSV timeline of suspicious processes.
 The default minimum level of alerts is high.
-You can change the minimum level with -l, --level=.
-  """
+You can change the minimum level with -l, --level=."""
 
 type
   TimelineSuspiciousProcessesCmd* = ref object of AbstractCmd

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -1,210 +1,192 @@
-proc timelineSuspiciousProcesses(level: string = "high", output: string = "", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
-    checkArgs(quiet, timeline, "informational")
+const TimelineSuspiciousProcessesMsg =
+  """
+  This command will create a CSV timeline of suspicious processes.
+  The default minimum level of alerts is high.
+  You can change the minimum level with -l, --level=.
+  """
 
-    echo "Started the Timeline Suspicious Processes command"
-    echo ""
-    echo "This command will create a CSV timeline of suspicious processes."
-    echo "The default minimum level of alerts is high."
-    echo "You can change the minimum level with -l, --level=."
-    echo ""
+type
+  TimelineSuspiciousProcessesCmd* = ref object of AbstractCmd
+      level*:string
+      seqOfResultsTables*: seq[Table[string, string]]
+      suspicousProcessCount_Sec_4688*, suspicousProcessCount_Sysmon_1* = 0
 
-    let totalLines = countLinesInTimeline(timeline)
+method filter*(self: TimelineSuspiciousProcessesCmd, x: HayabusaJson):bool =
+    return isMinLevel(x.Level, self.level) and (x.Channel == "Sec" and x.EventId == 4688) or (x.Channel == "Sysmon" and x.EventId == 1)
 
-    if level == "critical":
-        echo "Scanning for processes with an alert level of critical"
-    else:
-        echo "Scanning for processes with a minimal alert level of " & level
-    echo ""
-
+method analyze*(self: TimelineSuspiciousProcessesCmd, x: HayabusaJson) =
+    # Found a Security 4688 process creation event
     var
-        seqOfResultsTables: seq[Table[string, string]]
-        suspicousProcessCount_Sec_4688, suspicousProcessCount_Sysmon_1, eventId,pidInt = 0
-        channel, cmdLine, company, computer, description, eventLevel, eventType, hashes, hash_MD5, hash_SHA1, hash_SHA256, hash_IMPHASH,
+        eventId,pidInt = 0
+        channel, cmdLine, company, computer, description, eventLevel, eventType,
+            hashes, hash_MD5, hash_SHA1, hash_SHA256, hash_IMPHASH,
             lid, lguid, ruleAuthor,ruleTitle, parentCmdline,
             parentGuid, parentPid, pidStr, process, processGuid, product, timestamp, user = ""
-        jsonLine: JsonNode
-        bar: SuruBar = initSuruBar()
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        let eventId = jsonLine.EventID
-        let channel = jsonLine.Channel
-        let eventLevel = jsonLine.Level
-
-        # Found a Security 4688 process creation event
-        if channel == "Sec" and eventId == 4688 and isMinLevel(eventLevel, level) == true:
-            inc suspicousProcessCount_Sec_4688
-            try:
-                cmdLine = jsonLine.Details["Cmdline"].getStr()
-            except KeyError:
-                cmdLine = ""
-            eventType = "Security 4688"
-            timestamp = jsonLine.Timestamp
-            ruleTitle = jsonLine.RuleTitle
-            computer = jsonLine.Computer
-            process = jsonLine.Details["Proc"].getStr()
-            pidStr = $jsonLine.Details["PID"].getInt()
-            user = jsonLine.Details["User"].getStr()
-            lid = jsonLine.Details["LID"].getStr()
-            try:
-              if pidStr == "0":
-                # -F, --no-field-data-mapping JSONL requires hex conversion
-                pidStr = intToStr(fromHex[int](jsonLine.Details["PID"].getStr()))
-            except ValueError:
-              discard
-            try:
-                ruleAuthor = jsonLine.RuleAuthor
-            except KeyError:
-                ruleAuthor = ""
-
-            if output == "": # Output to screen
-                echo "Timestamp: " & timestamp
-                echo "Computer: " & computer
-                echo "Type: " & eventType
-                echo "Level: " & eventLevel
-                echo "Rule: " & ruleTitle
-                echo "RuleAuthor: " & ruleAuthor
-                echo "Cmdline: " & cmdLine
-                echo "Process: " & process
-                echo "PID: " & pidStr
-                echo "User: " & user
-                echo "LID: " & lid
-                echo ""
-            else: # Add records to seqOfResultsTables to eventually save to file.
-                var singleResultTable = initTable[string, string]()
-                singleResultTable["Timestamp"] = timestamp
-                singleResultTable["Computer"] = computer
-                singleResultTable["Type"] = eventType
-                singleResultTable["Level"] = eventLevel
-                singleResultTable["Rule"] = ruleTitle
-                singleResultTable["RuleAuthor"] = ruleAuthor
-                singleResultTable["Cmdline"] = cmdLine
-                singleResultTable["Process"] = process
-                singleResultTable["PID"] = pidStr
-                singleResultTable["User"] = user
-                singleResultTable["LID"] = lid
-                seqOfResultsTables.add(singleResultTable)
-
-        # Found a Sysmon 1 process creation event
-        if channel == "Sysmon" and eventId == 1 and isMinLevel(eventLevel, level) == true:
-            inc suspicousProcessCount_Sysmon_1
+    let jsonLine = x
+    if x.Channel == "Sec" and x.EventId == 4688 and isMinLevel(x.Level, self.level):
+        inc self.suspicousProcessCount_Sec_4688
+        try:
             cmdLine = jsonLine.Details["Cmdline"].getStr()
-            eventType = "Sysmon 1"
-            timestamp = jsonLine.Timestamp
-            ruleTitle = jsonLine.RuleTitle
-            computer = jsonLine.Computer
-            process = jsonLine.Details["Proc"].getStr()
-            pidStr = $jsonLine.Details["PID"].getInt()
-            user = jsonLine.Details["User"].getStr()
-            lid = jsonLine.Details["LID"].getStr()
-            lguid = jsonLine.Details["LGUID"].getStr()
-            processGuid = jsonLine.Details["PGUID"].getStr()
-            parentCmdline = jsonLine.Details["ParentCmdline"].getStr()
-            parentPid = $jsonLine.Details["ParentPID"].getInt()
-            parentGuid = jsonLine.Details["ParentPGUID"].getStr()
-            description = jsonLine.Details["Description"].getStr()
-            product = jsonLine.Details["Product"].getStr()
-            try:
-                company = jsonLine.Details["Company"].getStr()
-            except KeyError:
-                company = ""
-            try:
-                ruleAuthor = jsonLine.RuleAuthor
-            except KeyError:
-                ruleAuthor = ""
-            try:
-                hashes = jsonLine.Details["Hashes"].getStr() # Hashes are not enabled by default so this field may not exist.
-                let pairs = hashes.split(",")  # Split the string into key-value pairs. Ex: MD5=DE9C75F34F47B60A71BBA03760F0579E,SHA256=12F06D3B1601004DB3F7F1A07E7D3AF4CC838E890E0FF50C51E4A0C9366719ED,IMPHASH=336674CB3C8337BDE2C22255345BFF43
-                for pair in pairs:
-                    let keyVal = pair.split("=")
-                    case keyVal[0]:
-                    of "MD5":
-                        hash_MD5 = keyVal[1]
-                    of "SHA1":
-                        hash_SHA1 = keyVal[1]
-                    of "SHA256":
-                        hash_SHA256 = keyVal[1]
-                    of "IMPHASH":
-                        hash_IMPHASH = keyVal[1]
-            except KeyError:
-                hashes = ""
-                hash_MD5 = ""
-                hash_SHA1 = ""
-                hash_SHA256 = ""
-                hash_IMPHASH = ""
+        except KeyError:
+            cmdLine = ""
+        eventType = "Security 4688"
+        timestamp = jsonLine.Timestamp
+        ruleTitle = jsonLine.RuleTitle
+        computer = jsonLine.Computer
+        process = jsonLine.Details["Proc"].getStr()
+        pidStr = $jsonLine.Details["PID"].getInt()
+        user = jsonLine.Details["User"].getStr()
+        lid = jsonLine.Details["LID"].getStr()
+        try:
+          if pidStr == "0":
+            # -F, --no-field-data-mapping JSONL requires hex conversion
+            pidStr = intToStr(fromHex[int](jsonLine.Details["PID"].getStr()))
+        except ValueError:
+          discard
+        try:
+            ruleAuthor = jsonLine.RuleAuthor
+        except KeyError:
+            ruleAuthor = ""
 
-            if output == "": # Output to screen
-                echo "Timestamp: " & timestamp
-                echo "Computer: " & computer
-                echo "Type: " & eventType
-                echo "Level: " & eventLevel
-                echo "Rule: " & ruleTitle
-                echo "RuleAuthor: " & ruleAuthor
-                echo "Cmdline: " & cmdLine
-                echo "Process: " & process
-                echo "PID: " & pidStr
-                echo "User: " & user
-                echo "LID: " & lid
-                echo "LGUID: " & lguid
-                echo "ProcessGUID: " & processGuid
-                echo "ParentCmdline: " & parentCmdline
-                echo "ParentPID: " & parentPid
-                echo "ParentGUID: " & parentGuid
-                echo "Description: " & description
-                echo "Product: " & product
-                echo "Company: " & company
-                echo "MD5 Hash: " & hash_MD5
-                echo "SHA1 Hash: " & hash_SHA1
-                echo "SHA256 Hash: " & hash_SHA256
-                echo "Import Hash: " & hash_IMPHASH
-                echo ""
-            else: # Add records to seqOfResultsTables to eventually save to file.
-                var singleResultTable = initTable[string, string]()
-                singleResultTable["Timestamp"] = timestamp
-                singleResultTable["Computer"] = computer
-                singleResultTable["Type"] = eventType
-                singleResultTable["Level"] = eventLevel
-                singleResultTable["Rule"] = ruleTitle
-                singleResultTable["RuleAuthor"] = ruleAuthor
-                singleResultTable["Cmdline"] = cmdLine
-                singleResultTable["Process"] = process
-                singleResultTable["PID"] = pidStr
-                singleResultTable["User"] = user
-                singleResultTable["LID"] = lid
-                singleResultTable["LGUID"] = lguid
-                singleResultTable["ProcessGUID"] = processGuid
-                singleResultTable["ParentCmdline"] = parentCmdline
-                singleResultTable["ParentPID"] = parentPid
-                singleResultTable["ParentPGUID"] = parentGuid
-                singleResultTable["Description"] = description
-                singleResultTable["Product"] = product
-                singleResultTable["Company"] = company
-                singleResultTable["MD5 Hash"] = hash_MD5
-                singleResultTable["SHA1 Hash"] = hash_SHA1
-                singleResultTable["SHA256 Hash"] = hash_SHA256
-                singleResultTable["Import Hash"] = hash_IMPHASH
-                seqOfResultsTables.add(singleResultTable)
-    bar.finish()
+        if self.output == "": # Output to screen
+            echo "Timestamp: " & timestamp
+            echo "Computer: " & computer
+            echo "Type: " & eventType
+            echo "Level: " & eventLevel
+            echo "Rule: " & ruleTitle
+            echo "RuleAuthor: " & ruleAuthor
+            echo "Cmdline: " & cmdLine
+            echo "Process: " & process
+            echo "PID: " & pidStr
+            echo "User: " & user
+            echo "LID: " & lid
+            echo ""
+        else: # Add records to seqOfResultsTables to eventually save to file.
+            var singleResultTable = initTable[string, string]()
+            singleResultTable["Timestamp"] = timestamp
+            singleResultTable["Computer"] = computer
+            singleResultTable["Type"] = eventType
+            singleResultTable["Level"] = eventLevel
+            singleResultTable["Rule"] = ruleTitle
+            singleResultTable["RuleAuthor"] = ruleAuthor
+            singleResultTable["Cmdline"] = cmdLine
+            singleResultTable["Process"] = process
+            singleResultTable["PID"] = pidStr
+            singleResultTable["User"] = user
+            singleResultTable["LID"] = lid
+            self.seqOfResultsTables.add(singleResultTable)
 
-    if output != "" and (suspicousProcessCount_Sec_4688 > 0 or suspicousProcessCount_Sysmon_1 > 0): # Save results to CSV
+    # Found a Sysmon 1 process creation event
+    if x.Channel == "Sysmon" and x.EventId == 1 and isMinLevel(x.Level, self.level):
+        inc self.suspicousProcessCount_Sysmon_1
+        cmdLine = jsonLine.Details["Cmdline"].getStr()
+        eventType = "Sysmon 1"
+        timestamp = jsonLine.Timestamp
+        ruleTitle = jsonLine.RuleTitle
+        computer = jsonLine.Computer
+        process = jsonLine.Details["Proc"].getStr()
+        pidStr = $jsonLine.Details["PID"].getInt()
+        user = jsonLine.Details["User"].getStr()
+        lid = jsonLine.Details["LID"].getStr()
+        lguid = jsonLine.Details["LGUID"].getStr()
+        processGuid = jsonLine.Details["PGUID"].getStr()
+        parentCmdline = jsonLine.Details["ParentCmdline"].getStr()
+        parentPid = $jsonLine.Details["ParentPID"].getInt()
+        parentGuid = jsonLine.Details["ParentPGUID"].getStr()
+        description = jsonLine.Details["Description"].getStr()
+        product = jsonLine.Details["Product"].getStr()
+        try:
+            company = jsonLine.Details["Company"].getStr()
+        except KeyError:
+            company = ""
+        try:
+            ruleAuthor = jsonLine.RuleAuthor
+        except KeyError:
+            ruleAuthor = ""
+        try:
+            hashes = jsonLine.Details["Hashes"].getStr() # Hashes are not enabled by default so this field may not exist.
+            let pairs = hashes.split(",")  # Split the string into key-value pairs. Ex: MD5=DE9C75F34F47B60A71BBA03760F0579E,SHA256=12F06D3B1601004DB3F7F1A07E7D3AF4CC838E890E0FF50C51E4A0C9366719ED,IMPHASH=336674CB3C8337BDE2C22255345BFF43
+            for pair in pairs:
+                let keyVal = pair.split("=")
+                case keyVal[0]:
+                of "MD5":
+                    hash_MD5 = keyVal[1]
+                of "SHA1":
+                    hash_SHA1 = keyVal[1]
+                of "SHA256":
+                    hash_SHA256 = keyVal[1]
+                of "IMPHASH":
+                    hash_IMPHASH = keyVal[1]
+        except KeyError:
+            hashes = ""
+            hash_MD5 = ""
+            hash_SHA1 = ""
+            hash_SHA256 = ""
+            hash_IMPHASH = ""
+
+        if self.output == "": # Output to screen
+            echo "Timestamp: " & timestamp
+            echo "Computer: " & computer
+            echo "Type: " & eventType
+            echo "Level: " & eventLevel
+            echo "Rule: " & ruleTitle
+            echo "RuleAuthor: " & ruleAuthor
+            echo "Cmdline: " & cmdLine
+            echo "Process: " & process
+            echo "PID: " & pidStr
+            echo "User: " & user
+            echo "LID: " & lid
+            echo "LGUID: " & lguid
+            echo "ProcessGUID: " & processGuid
+            echo "ParentCmdline: " & parentCmdline
+            echo "ParentPID: " & parentPid
+            echo "ParentGUID: " & parentGuid
+            echo "Description: " & description
+            echo "Product: " & product
+            echo "Company: " & company
+            echo "MD5 Hash: " & hash_MD5
+            echo "SHA1 Hash: " & hash_SHA1
+            echo "SHA256 Hash: " & hash_SHA256
+            echo "Import Hash: " & hash_IMPHASH
+            echo ""
+        else: # Add records to seqOfResultsTables to eventually save to file.
+            var singleResultTable = initTable[string, string]()
+            singleResultTable["Timestamp"] = timestamp
+            singleResultTable["Computer"] = computer
+            singleResultTable["Type"] = eventType
+            singleResultTable["Level"] = eventLevel
+            singleResultTable["Rule"] = ruleTitle
+            singleResultTable["RuleAuthor"] = ruleAuthor
+            singleResultTable["Cmdline"] = cmdLine
+            singleResultTable["Process"] = process
+            singleResultTable["PID"] = pidStr
+            singleResultTable["User"] = user
+            singleResultTable["LID"] = lid
+            singleResultTable["LGUID"] = lguid
+            singleResultTable["ProcessGUID"] = processGuid
+            singleResultTable["ParentCmdline"] = parentCmdline
+            singleResultTable["ParentPID"] = parentPid
+            singleResultTable["ParentPGUID"] = parentGuid
+            singleResultTable["Description"] = description
+            singleResultTable["Product"] = product
+            singleResultTable["Company"] = company
+            singleResultTable["MD5 Hash"] = hash_MD5
+            singleResultTable["SHA1 Hash"] = hash_SHA1
+            singleResultTable["SHA256 Hash"] = hash_SHA256
+            singleResultTable["Import Hash"] = hash_IMPHASH
+            self.seqOfResultsTables.add(singleResultTable)
+
+method resultOutput*(self: TimelineSuspiciousProcessesCmd)=
+    if self.output != "" and (self.suspicousProcessCount_Sec_4688 > 0 or self.suspicousProcessCount_Sysmon_1 > 0): # Save results to CSV
         # Open file to save results
-        var outputFile = open(output, fmWrite)
         let header = ["Timestamp", "Computer", "Type", "Level", "Rule", "RuleAuthor", "Cmdline", "Process", "PID", "User", "LID", "LGUID", "ProcessGUID", "ParentCmdline", "ParentPID", "ParentPGUID", "Description", "Product", "Company", "MD5 Hash", "SHA1 Hash", "SHA256 Hash", "Import Hash"]
+        var outputFile = open(self.output, fmWrite)
 
         ## Write CSV header
         outputFile.write(header.join(",") & "\p")
 
         ## Write contents
-        for table in seqOfResultsTables:
+        for table in self.seqOfResultsTables:
             for key in header:
                 if table.hasKey(key):
                     outputFile.write(escapeCsvField(table[key]) & ",")
@@ -212,19 +194,28 @@ proc timelineSuspiciousProcesses(level: string = "high", output: string = "", qu
                     outputFile.write(",")
             outputFile.write("\p")
         outputFile.close()
-        let fileSize = getFileSize(output)
+        let fileSize = getFileSize(self.output)
 
         echo ""
-        echo "Saved results to " & output & " (" & formatFileSize(fileSize) & ")"
+        echo "Saved results to " & self.output & " (" & formatFileSize(fileSize) & ")"
         echo ""
 
-    if suspicousProcessCount_Sec_4688 == 0 and suspicousProcessCount_Sysmon_1 == 0:
+    if self.suspicousProcessCount_Sec_4688 == 0 and self.suspicousProcessCount_Sysmon_1 == 0:
         echo ""
         echo "No suspicous processes were found. There are either no malicious processes or you need to change the level."
         echo ""
         return
 
-    echo "Suspicious processes in Security 4688 process creation events: " & intToStr(suspicousProcessCount_Sec_4688).insertSep(',')
-    echo "Suspicious processes in Sysmon 1 process creation events: " & intToStr(suspicousProcessCount_Sysmon_1).insertSep(',')
+    echo "Suspicious processes in Security 4688 process creation events: " & intToStr(self.suspicousProcessCount_Sec_4688).insertSep(',')
+    echo "Suspicious processes in Sysmon 1 process creation events: " & intToStr(self.suspicousProcessCount_Sysmon_1).insertSep(',')
     echo ""
-    outputElapsedTime(startTime)
+
+proc timelineSuspiciousProcesses(level: string = "high", output: string = "", quiet: bool = false, timeline: string) =
+    checkArgs(quiet, timeline, "informational")
+    let cmd = TimelineSuspiciousProcessesCmd(
+                timeline: timeline,
+                output: output,
+                level: level,
+                name:"Timeline Suspicious Processes",
+                msg: TimelineSuspiciousProcessesMsg)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/timelineSuspiciousProcesses.nim
+++ b/src/takajopkg/timelineSuspiciousProcesses.nim
@@ -1,8 +1,8 @@
 const TimelineSuspiciousProcessesMsg =
   """
-  This command will create a CSV timeline of suspicious processes.
-  The default minimum level of alerts is high.
-  You can change the minimum level with -l, --level=.
+This command will create a CSV timeline of suspicious processes.
+The default minimum level of alerts is high.
+You can change the minimum level with -l, --level=.
   """
 
 type

--- a/src/takajopkg/timelineTasks.nim
+++ b/src/takajopkg/timelineTasks.nim
@@ -94,9 +94,10 @@ method resultOutput*(self: TimelineTasksCmd)=
     echo "Saved results to " & self.output & " (" & formatFileSize(fileSize) & ")"
     echo ""
 
-proc timelineTasks(output: string, outputLogoffEvents: bool = false, quiet: bool = false, timeline: string) =
+proc timelineTasks(skipProgressBar:bool = false, output: string, outputLogoffEvents: bool = false, quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = TimelineTasksCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"Timeline Tasks",

--- a/src/takajopkg/ttpSummary.nim
+++ b/src/takajopkg/ttpSummary.nim
@@ -1,4 +1,4 @@
-const TTPSummaryMsg = "Started the TTP Summary command.\nThis command outputs TTP summary."
+const TTPSummaryMsg = "This command outputs TTP summary."
 
 proc readJsonFromFile(filename: string): JsonNode =
     var

--- a/src/takajopkg/ttpSummary.nim
+++ b/src/takajopkg/ttpSummary.nim
@@ -102,12 +102,13 @@ method resultOutput*(self: TTPSummaryCmd) =
         echo "No MITRE ATT&CK tags were found in the Hayabusa results."
         echo "Please run your Hayabusa scan with a profile that includes the %MitreTags% field. (ex: -p verbose)"
 
-proc ttpSummary(output: string = "", quiet: bool = false, timeline: string) =
+proc ttpSummary(skipProgressBar:bool = false, output: string = "", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     if not os.fileExists("mitre-attack.json"):
         echo "The file '" & "mitre-attack.json" & "' does not exist. Please specify a valid file path."
         quit(1)
     let cmd = TTPSummaryCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"TTP Summary",

--- a/src/takajopkg/ttpSummary.nim
+++ b/src/takajopkg/ttpSummary.nim
@@ -4,7 +4,9 @@ proc readJsonFromFile(filename: string): JsonNode =
     var
         file: File
         content: string
-    if file.open(filename):
+    if not os.fileExists(filename):
+        result = parseJson("{}")
+    elif file.open(filename):
         content = file.readAll()
         file.close()
         result = parseJson(content)

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -1,8 +1,4 @@
-const TTPVisualizeMsg =
-  """
-Started the TTP Visualize command.
-This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
-  """
+const TTPVisualizeMsg = "This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator."
 
 type
   TTPVisualizeCmd* = ref object of AbstractCmd

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -1,8 +1,8 @@
 const TTPVisualizeMsg =
-    """
-    Started the TTP Visualize command.
-    This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
-    """
+  """
+  Started the TTP Visualize command.
+  This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
+  """
 
 type
   TTPVisualizeCmd* = ref object of AbstractCmd

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -26,9 +26,10 @@ method analyze*(self: TTPVisualizeCmd, x: HayabusaJson) =
 method resultOutput*(self: TTPVisualizeCmd) =
     outputTTPResult(self.stackedMitreTags, self.stackedMitreTagsCount, self.output)
 
-proc ttpVisualize(output: string = "mitre-ttp-heatmap.json", quiet: bool = false, timeline: string) =
+proc ttpVisualize(skipProgressBar:bool = false, output: string = "mitre-ttp-heatmap.json", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")
     let cmd = TTPVisualizeCmd(
+                skipProgressBar: skipProgressBar,
                 timeline: timeline,
                 output: output,
                 name:"TTP Visualize",

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -1,7 +1,7 @@
 const TTPVisualizeMsg =
   """
-  Started the TTP Visualize command.
-  This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
+Started the TTP Visualize command.
+This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
   """
 
 type

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -1,41 +1,32 @@
+const TTPVisualizeMsg = "Started the TTP Visualize command.\nThis command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator."
+
+type
+  TTPVisualizeCmd* = ref object of AbstractCmd
+    stackedMitreTags* = initTable[string, string]()
+    stackedMitreTagsCount* = initTable[string, int]()
+
+method analyze*(self: TTPVisualizeCmd, x: HayabusaJson) =
+    try:
+        for tag in x.MitreTags:
+            let techniqueID = tag
+            let ruleTitle = strip(x.RuleTitle)
+            if self.stackedMitreTags.hasKey(techniqueID) and ruleTitle notin self.stackedMitreTags[techniqueID]:
+                self.stackedMitreTags[techniqueID] = self.stackedMitreTags[techniqueID] & "," & ruleTitle
+                self.stackedMitreTagsCount[techniqueID] += 1
+            else:
+                self.stackedMitreTags[techniqueID] = ruleTitle
+                self.stackedMitreTagsCount[techniqueID] = 1
+    except CatchableError:
+        discard
+
+method resultOutput*(self: TTPVisualizeCmd) =
+    outputTTPResult(self.stackedMitreTags, self.stackedMitreTagsCount, self.output)
+
 proc ttpVisualize(output: string = "mitre-ttp-heatmap.json", quiet: bool = false, timeline: string) =
-    let startTime = epochTime()
     checkArgs(quiet, timeline, "informational")
-
-    echo "Started the TTP Visualize command."
-    echo "This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator."
-    echo ""
-
-    let totalLines = countLinesInTimeline(timeline)
-
-    var
-        bar: SuruBar = initSuruBar()
-        stackedMitreTags = initTable[string, string]()
-        stackedMitreTagsCount = initTable[string, int]()
-
-    bar[0].total = totalLines
-    bar.setup()
-
-    for line in lines(timeline):
-        inc bar
-        bar.update(1000000000) # refresh every second
-        let jsonLineOpt = parseLine(line)
-        if jsonLineOpt.isNone:
-            continue
-        let jsonLine:HayabusaJson = jsonLineOpt.get()
-        try:
-            for tag in jsonLine.MitreTags:
-                let techniqueID = tag
-                let ruleTitle = strip(jsonLine.RuleTitle)
-                if stackedMitreTags.hasKey(techniqueID) and ruleTitle notin stackedMitreTags[techniqueID]:
-                    stackedMitreTags[techniqueID] = stackedMitreTags[techniqueID] & "," & ruleTitle
-                    stackedMitreTagsCount[techniqueID] += 1
-                else:
-                    stackedMitreTags[techniqueID] = ruleTitle
-                    stackedMitreTagsCount[techniqueID] = 1
-        except CatchableError:
-            continue
-
-    bar.finish()
-    outputTTPResult(stackedMitreTags, stackedMitreTagsCount, output)
-    outputElapsedTime(startTime)
+    let cmd = TTPVisualizeCmd(
+                timeline: timeline,
+                output: output,
+                name:"TTP Visualize",
+                msg: TTPVisualizeMsg)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -1,4 +1,8 @@
-const TTPVisualizeMsg = "Started the TTP Visualize command.\nThis command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator."
+const TTPVisualizeMsg =
+    """
+    Started the TTP Visualize command.
+    This command extracts TTPs and creates a JSON file to visualize in MITRE ATT&CK Navigator.
+    """
 
 type
   TTPVisualizeCmd* = ref object of AbstractCmd


### PR DESCRIPTION
## What Changed
### New Feature
- Closed #121 
  - Applies only to commands that take JSONL as input 
### Refactoring
- Related: #99 
- Related: #132
- Apply [Template method pattern](https://refactoring.guru/design-patterns/template-method) for `automagic` command
   - Refactoring to reuse logic in `automagic` as below 
      - [src/takajopkg/automagic.nim](https://github.com/Yamato-Security/takajo/blob/refactor-for-automagic-command/src/takajopkg/automagic.nim)
         - The `automagic` command is commented out in this PR. I will create another PR for `automagic`.  
   - The common behavior for all commands that take JSONL as input is defined below
      -  [src/takajopkg/takajoCore.nim](https://github.com/Yamato-Security/takajo/blob/refactor-for-automagic-command/src/takajopkg/takajoCore.nim) 
   -  For processing specific to each command, extend `AbstractCmd` and create a subclass for each command and implement `filter/analyze/resultOutput` method
       - e.g [stack-dns](https://github.com/Yamato-Security/takajo/blob/9ec2ea391b5a3fd7e620913bac53ebbbff2ffc51/src/takajopkg/stackDNS.nim#L3-L23) 

## Integration-Test
I confirmed that the integration test is successful as shown below.
https://github.com/Yamato-Security/takajo/actions/runs/8267602168
also I confirmed that the progress bar is not displayed when the -s option is added.

## Test
### Environment
- OS: macOS Sonoma version 14.2.1
- Hayabusa v2.14.0-dev
- Nim: 2.0.2
- nimble: 0.14.2

Sorry for the PR with a lot of commits...
I would appreciate it if you could check it out when you have time🙏