### PR TITLE
fix: ttp-visualize/ttp-summary command does not extract count related rule

### DIFF
--- a/src/takajopkg/ttpResult.nim
+++ b/src/takajopkg/ttpResult.nim
@@ -12,7 +12,7 @@ type TTPResult* = ref object
 proc newTTPResult*(techniqueID: string, comment: string, score: int): TTPResult =
   result = TTPResult(techniqueID: techniqueID, comment: comment, score:score)
 
-proc outputTTPResult*(stackedMitreTags:Table[string, string], stackedMitreTagsCount:Table[string, int], output:string) =
+proc outputTTPResult*(stackedMitreTags:Table[string, string], stackedMitreTagsCount:Table[string, int], output:string, name:string) =
     echo ""
     if stackedMitreTags.len == 0:
         echo "No MITRE ATT&CK tags were found in the Hayabusa results."
@@ -24,14 +24,14 @@ proc outputTTPResult*(stackedMitreTags:Table[string, string], stackedMitreTagsCo
             let score = toInt(round(stackedMitreTagsCount[techniqueID]/maxCount * 100))
             mitreTags.add(newTTPResult(techniqueID, ruleTitle, score))
         let jsonObj = %* {
-                            "name": "Hayabusa detection result heatmap",
+                            "name": name,
                             "versions": {
                                 "attack": "14",
                                 "navigator": "4.9.1",
                                 "layer": "4.5"
                             },
                             "domain": "enterprise-attack",
-                            "description": "Sigma rule heatmap",
+                            "description": name,
                             "techniques": mitreTags,
                             "gradient": {
                                 "colors": [

--- a/src/takajopkg/ttpVisualize.nim
+++ b/src/takajopkg/ttpVisualize.nim
@@ -20,7 +20,8 @@ method analyze*(self: TTPVisualizeCmd, x: HayabusaJson) =
         discard
 
 method resultOutput*(self: TTPVisualizeCmd) =
-    outputTTPResult(self.stackedMitreTags, self.stackedMitreTagsCount, self.output)
+    let name = "Hayabusa detection result heatmap"
+    outputTTPResult(self.stackedMitreTags, self.stackedMitreTagsCount, self.output, name)
 
 proc ttpVisualize(skipProgressBar:bool = false, output: string = "mitre-ttp-heatmap.json", quiet: bool = false, timeline: string) =
     checkArgs(quiet, timeline, "informational")

--- a/src/takajopkg/ttpVisualizeSigma.nim
+++ b/src/takajopkg/ttpVisualizeSigma.nim
@@ -42,5 +42,6 @@ proc ttpVisualizeSigma(output: string = "mitre-attack-navigator.json", quiet: bo
                         stackedMitreTags[techniqueID] = ruleTitle
                         stackedMitreTagsCount[techniqueID] = 1
     bar.finish()
-    outputTTPResult(stackedMitreTags, stackedMitreTagsCount, output)
+    let name = "Sigma rule heatmap"
+    outputTTPResult(stackedMitreTags, stackedMitreTagsCount, output, name)
     outputElapsedTime(startTime)


### PR DESCRIPTION
## What Changed
- Closed: #136 

## Test
### Environment
- OS: macOS Sonoma version 14.2.1
- Hayabusa v2.13.0
- Nim: 2.0.2
- nimble: 0.14.2

I confirmed that there is no difference between the execution results of the ttp-visualize command in 2.4.0 and the following.
```
% ./takajo ttp-visualize -t timeline.jsonl
% diff mitre-ttp-heatmap.json mitre-attack-navigator.json
%
```

In the integration test below, I confirmed that the all commands succeeded.
- https://github.com/Yamato-Security/takajo/actions/runs/8298558745

I would appreciate it if you could check it out when you have time🙏