### PR TITLE
fix: automagic crash when not verbose profile jsonl

### DIFF
--- a/src/takajopkg/ttpResult.nim
+++ b/src/takajopkg/ttpResult.nim
@@ -14,10 +14,12 @@ proc newTTPResult*(techniqueID: string, comment: string, score: int): TTPResult 
 
 proc outputTTPResult*(stackedMitreTags:Table[string, string], stackedMitreTagsCount:Table[string, int], output:string, displayTable:bool = true, name:string):string =
     var savedFiles = "n/a"
-    if displayTable and stackedMitreTags.len == 0:
-        echo ""
-        echo "No MITRE ATT&CK tags were found in the Hayabusa results."
-        echo "Please run your Hayabusa scan with a profile that includes the %MitreTags% field. (ex: -p verbose)"
+    if stackedMitreTags.len == 0:
+        savedFiles = "No MITRE ATT&CK tags were found in the Hayabusa results."
+        if displayTable:
+            echo ""
+            echo savedFiles
+            echo "Please run your Hayabusa scan with a profile that includes the %MitreTags% field. (ex: -p verbose)"
     else:
         var mitreTags = newSeq[TTPResult]()
         let maxCount = stackedMitreTagsCount.values.toSeq.max
@@ -61,4 +63,4 @@ proc outputTTPResult*(stackedMitreTags:Table[string, string], stackedMitreTagsCo
         if displayTable:
             echo ""
             echo "Saved file: " & savedFiles
-        return savedFiles
+    return savedFiles

--- a/src/takajopkg/ttpSummary.nim
+++ b/src/takajopkg/ttpSummary.nim
@@ -107,9 +107,10 @@ method resultOutput*(self: TTPSummaryCmd) =
             ruleStr = initHashSet[string]()
         table.echoTableSepsWithStyled(seps = boxSeps)
         echo ""
-    if self.displayTable:
-        if self.seqOfResultsTables.len == 0:
-            echo "No MITRE ATT&CK tags were found in the Hayabusa results."
+    if self.seqOfResultsTables.len == 0:
+        savedFiles = "No MITRE ATT&CK tags were found in the Hayabusa results."
+        if self.displayTable:
+            echo savedFiles
             echo "Please run your Hayabusa scan with a profile that includes the %MitreTags% field. (ex: -p verbose)"
     self.cmdResult = CmdResult(results:results, savedFiles:savedFiles)
 


### PR DESCRIPTION
## What Changed
- Closed: #143 

## Test
### Environment
- OS: macOS Sonoma version 14.2.1
- Hayabusa v2.14.0-dev
- Nim: 2.0.2
- nimble: 0.14.2

I confirmed that it does not crash as follows.
```
% ./hayabusa json-timeline -d ../hayabusa-sample-evtx -o timeline-standard.jsonl -L -w
% ./takajo automagic -t timeline-standard.jsonl -q
Started the automagic command

Automatically executes as many commands as possible and output results to a new folder.

File: timeline-standard.jsonl (31.97 MB)
Counting total lines. Please wait.
Total lines: 32,363

Scanning the Hayabusa timeline. Please wait.

100%|█████████████████████████| 32363/32363 [ 0.6s< 0.0s,  83.13k/sec]

┌───────────────────────────────┬──────────────────────────────────────────────────────┬──────────────────────────────────────────────────────┐
│ Command                       │ Results                                              │ Saved Files                                          │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ extract-scriptblocks          │ PowerShell logs: 108                                 │ case-1/scriptblock-logs/Summary.csv (19.76 KB)       │
│                               │                                                      │ case-1/scriptblock-logs/*.txt                        │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ list-domains                  │ Domains: 0                                           │ case-1/ListDomains.txt (0 Bytes)                     │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ list-domains(detailed)        │ Domains: 2                                           │ case-1/ListDomainsDetailed.txt (14 Bytes)            │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ list-hashes                   │ MD5: 880                                             │ case-1/ListHashes-MD5.txt (4.32 KB)                  │
│                               │ SHA1: 821                                            │ case-1/ListHashes-SHA1.txt (5.08 KB)                 │
│                               │ SHA256: 824                                          │ case-1/ListHashes-SHA256.txt (8.19 KB)               │
│                               │ Import: 880                                          │ case-1/ListHashes-ImportHashes.txt (3.96 KB)         │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ list-ip-addresses             │ IP adddresses: 0                                     │ case-1/ListIP-Addresses.txt (0 Bytes)                │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-cmdlines                │ Unique cmdlines: 1,222                               │ case-1/StackCmdlines.csv (411.33 KB)                 │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-computers               │ Unique computers: 53                                 │ case-1/StackTargetComputers.csv (45.18 KB)           │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-computers               │ Unique computers: 3,571                              │ case-1/StackSourceComputers.csv (379.83 KB)          │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-dns                     │ n/a                                                  │ n/a                                                  │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-ip-addresses(source)    │ Unique ip-addresses(source): 18                      │ case-1/StackSourceIP-Addresses.csv (2.03 KB)         │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-ip-addresses(target)    │ Unique ip-addresses(target): 13                      │ case-1/StackTargetIP-Addresses.csv (1.31 KB)         │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-logons                  │ Unique logons: 44                                    │ case-1/StackLogons.csv (2.69 KB)                     │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-processes               │ Unique processes: 138                                │ case-1/StackProcesses.csv (27.76 KB)                 │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-services                │ Unique services: 276                                 │ case-1/StackServices.csv (134.07 KB)                 │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-tasks                   │ n/a                                                  │ n/a                                                  │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-users(target)           │ Unique users(target): 37                             │ case-1/StackTargetUsers.csv (21.13 KB)               │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-users(no filtering)     │ Unique users(no filtering): 56                       │ case-1/StackTargetUsers-NoFiltering.csv (28.32 KB)   │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-users(source)           │ Unique users(source): 37                             │ case-1/StackSourceUsers.csv (21.13 KB)               │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ stack-users(no filtering)     │ Unique users(no filtering): 56                       │ case-1/StackSourceUsers-NoFiltering.csv (28.32 KB)   │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ timeline-logon                │ EID 4624 (Successful Logon): 310                     │ case-1/TimelineLogon.csv (732.00 KB)                 │
│                               │ EID 4625 (Failed Logon): 3,574                       │                                                      │
│                               │ EID 4634 (Logoff): 13                                │                                                      │
│                               │ EID 4647 (User Initiated Logoff): 27                 │                                                      │
│                               │ EID 4648 (Explicit Logon): 307                       │                                                      │
│                               │ EID 4672 (Admin Logon): 103                          │                                                      │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ timeline-partition-diagnostic │ Events: 0                                            │ case-1/TimelinePartitionDiagnostic.csv (80 Bytes)    │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ timeline-suspicious-processes │ Events: 3,535                                        │ case-1/TimelineSuspiciousProcesses.csv (2.32 MB)     │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ timeline-tasks                │ Events: 8                                            │ case-1/TimelineTask.csv (3.76 KB)                    │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ ttp-summary                   │ TTPs: 0                                              │ No MITRE ATT&CK tags were found in the Hayabusa      │
│                               │                                                      │ results.                                             │
├───────────────────────────────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────────────────┤
│ ttp-visualize                 │ You can import this into ATT&CK Navigator            │ No MITRE ATT&CK tags were found in the Hayabusa      │
│                               │                                                      │ results.                                             │
└───────────────────────────────┴──────────────────────────────────────────────────────┴──────────────────────────────────────────────────────┘

Elapsed time: 0 hours, 0 minutes, 0 seconds
```

https://github.com/Yamato-Security/takajo/actions/runs/8359146373

I would appreciate it if you could check it out when you have time🙏