### PR TITLE
feat: added `failedLogons` option `stack-logons`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## x.x.x [xxxx/xx/xx]
+
+**改善:**
+
+- `stack-logons`コマンドに`-f, --failedLogons`オプションを追加して、`automagic`コマンドで失敗したログイン集計を出力するようにした。 (#152) (@fukusuket)
+
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 
 **新機能:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## x.x.x [xxxx/xx/xx]
+
+**Enhancements:**
+
+- Added `-f, --failedLogons` to the `stack-logons` command and added stacked failed logon information to the `automagic` command output. (#152) (@fukusuket)
+
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 
 **New Features:**

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -58,7 +58,7 @@ include takajopkg/automagic
 
 
 when isMainModule:
-    clCfg.version = "2.5.0"
+    clCfg.version = "2.5.1-dev"
     const examples = "Examples:\p"
     const example_automagic = "  automagic -t ../hayabusa/timeline.jsonl [--level low] [--displayTable] -o case-1\p"
     const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low] -o scriptblock-logs\p"
@@ -73,7 +73,7 @@ when isMainModule:
     const example_stack_computers = "  stack-computers -t ../hayabusa/timeline.jsonl [--level informational] [--sourceComputers] [--skipProgressBar] -o computers.csv\p"
     const example_stack_dns = "  stack-dns -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o dns.csv\p"
     const example_stack_ip_addresses = "  stack-ip-addresses -t ../hayabusa/timeline.jsonl [--level infomational] [--targetIpAddresses] [--skipProgressBar] -o ipAddresses.csv\p"
-    const example_stack_logons = "  stack-logons -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o logons.csv\p"
+    const example_stack_logons = "  stack-logons -t ../hayabusa/timeline.jsonl [--skipProgressBar] [--failedLogons] -o logons.csv\p"
     const example_stack_processes = "  stack-processes -t ../hayabusa/timeline.jsonl [--level low] [--skipProgressBar] -o processes.csv\p"
     const example_stack_services  = "  stack-services -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o services.csv\p"
     const example_stack_tasks = "  stack-tasks -t ../hayabusa/timeline.jsonl [--level infomational] [--skipProgressBar] -o tasks.csv\p"
@@ -276,6 +276,7 @@ when isMainModule:
             doc = "stack logons by target user, target computer, source IP address and source computer",
             help = {
                 "localSrcIpAddresses": "include results when the source IP address is local",
+                "failedLogons": "stack failed logons instead of successful logons",
                 "output": "save results to a CSV file (default: stdout)",
                 "quiet": "do not display the launch banner (default: false)",
                 "skipProgressBar": "do not display the progress bar (default: false)",

--- a/src/takajopkg/automagic.nim
+++ b/src/takajopkg/automagic.nim
@@ -68,9 +68,13 @@ proc autoMagic(level: string = "informational", skipProgressBar: bool = false,
     output: output & "/StackTargetIP-Addresses.csv",
     targetIpAddresses: true)
 
-  # stack-logons -t ../hayabusa/timeline.jsonl -o case-1/Logons.csv
-  let cmd12 = StackLogonsCmd(name: "stack-logons", displayTable: displayTable,
-    timeline: timeline, output: output & "/StackLogons.csv")
+  # stack-logons -t ../hayabusa/timeline.jsonl -o case-1/StackLogons.csv
+  let cmd12 = StackLogonsCmd(name: "stack-logons(successful)", displayTable: displayTable,
+    timeline: timeline, output: output & "/StackSuccessfulLogons.csv")
+
+  # stack-logons -t ../hayabusa/timeline.jsonl --failedLogons -o case-1/StackFailedLogons.csv
+  let cmd122 = StackLogonsCmd(name: "stack-logons(failed)", displayTable: displayTable,
+    timeline: timeline, output: output & "/StackFailedLogons.csv", failedLogons:true)
 
   # stack-processes -t ../hayabusa/timeline.jsonl --level <level> -o case-1/Processes.csv
   let cmd13 = StackProcessesCmd(name: "stack-processes", level: level,
@@ -137,7 +141,7 @@ proc autoMagic(level: string = "informational", skipProgressBar: bool = false,
 
   # execute all command
   let cmds = @[cmd1, cmd2, cmd3, cmd4, cmd5, cmd6, cmd7, cmd8, cmd9, cmd10,
-        cmd11, cmd12, cmd13, cmd14, cmd15, cmd16, cmd17, cmd18, cmd19,
+        cmd11, cmd12, cmd122, cmd13, cmd14, cmd15, cmd16, cmd17, cmd18, cmd19,
         cmd20,
         cmd21, cmd22, cmd23, cmd24, cmd25]
   let cmd = AutoMagicCmd(level: level, skipProgressBar: skipProgressBar,


### PR DESCRIPTION
## What Changed
- Closed: #152 

## Test
### Environment
- OS: macOS Sonoma version 14.4.1
- Hayabusa v2.15.0-dev
- Nim: 2.0.2
- nimble: 0.14.2

### Integration-Test
https://github.com/Yamato-Security/takajo/actions/runs/8690500610/job/23830582091

### help
```
% ./takajo stack-logons -h
Usage:
  stack-logons [REQUIRED,optional-params]
stack logons by target user, target computer, source IP address and source computer
Options:
  -h, --help                                   print this cligen-erated help
  --help-syntax                                advanced: prepend,plurals,..
  --version                  bool    false     print version
  -l, --localSrcIpAddresses  bool    false     include results when the source IP address is local
  -f, --failedLogons         bool    false     stack failed logons instead of successful logons
  -s, --skipProgressBar      bool    false     do not display the progress bar (default: false)
  -o=, --output=             string  ""        save results to a CSV file (default: stdout)
  -q, --quiet                bool    false     do not display the launch banner (default: false)
  -t=, --timeline=           string  REQUIRED  Hayabusa JSONL timeline file or directory (profile: any besides all-field-info*)
```

I would appreciate it if you could check it out when you have time🙏