### PR TITLE
feat: update to MITRE ATT&CK v15.0

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,6 +5,7 @@
 **改善:**
 
 - `stack-logons`コマンドに`-f, --failedLogons`オプションを追加して、`automagic`コマンドで失敗したログイン集計を出力するようにした。 (#152) (@fukusuket)
+- MITRE ATT&CKをv15.0に更新した。 (#155) (@fukusuket)
 
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Enhancements:**
 
 - Added `-f, --failedLogons` to the `stack-logons` command and added stacked failed logon information to the `automagic` command output. (#152) (@fukusuket)
+- Updated MITRE ATT&CK to v15.0. (#155) (@fukusuket)
 
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 

--- a/mitre-attack.json
+++ b/mitre-attack.json
@@ -254,6 +254,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "Obfuscated Files or Information"
     },
+    "T1027.013": {
+        "Sub-Technique": "Encrypted/Encoded File",
+        "Tactic": "Defense Evasion",
+        "Technique": "Obfuscated Files or Information"
+    },
     "T1029": {
         "Sub-Technique": "-",
         "Tactic": "Exfiltration",
@@ -581,6 +586,11 @@
     },
     "T1059.009": {
         "Sub-Technique": "Cloud API",
+        "Tactic": "Execution",
+        "Technique": "Command and Scripting Interpreter"
+    },
+    "T1059.010": {
+        "Sub-Technique": "AutoHotKey & AutoIT",
         "Tactic": "Execution",
         "Technique": "Command and Scripting Interpreter"
     },
@@ -1259,6 +1269,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "System Script Proxy Execution"
     },
+    "T1216.002": {
+        "Sub-Technique": "SyncAppvPublishingServer",
+        "Tactic": "Defense Evasion",
+        "Technique": "System Script Proxy Execution"
+    },
     "T1217": {
         "Sub-Technique": "-",
         "Tactic": "Discovery",
@@ -1334,6 +1349,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "System Binary Proxy Execution"
     },
+    "T1218.015": {
+        "Sub-Technique": "Electron Applications",
+        "Tactic": "Defense Evasion",
+        "Technique": "System Binary Proxy Execution"
+    },
     "T1219": {
         "Sub-Technique": "-",
         "Tactic": "Command and Control",
@@ -1382,17 +1402,17 @@
     "T1484": {
         "Sub-Technique": "-",
         "Tactic": "Defense Evasion",
-        "Technique": "Domain Policy Modification"
+        "Technique": "Domain or Tenant Policy Modification"
     },
     "T1484.001": {
         "Sub-Technique": "Group Policy Modification",
         "Tactic": "Defense Evasion",
-        "Technique": "Domain Policy Modification"
+        "Technique": "Domain or Tenant Policy Modification"
     },
     "T1484.002": {
-        "Sub-Technique": "Domain Trust Modification",
+        "Sub-Technique": "Trust Modification",
         "Tactic": "Defense Evasion",
-        "Technique": "Domain Policy Modification"
+        "Technique": "Domain or Tenant Policy Modification"
     },
     "T1485": {
         "Sub-Technique": "-",
@@ -1649,6 +1669,11 @@
         "Tactic": "Privilege Escalation",
         "Technique": "Create or Modify System Process"
     },
+    "T1543.005": {
+        "Sub-Technique": "Container Service",
+        "Tactic": "Privilege Escalation",
+        "Technique": "Create or Modify System Process"
+    },
     "T1546": {
         "Sub-Technique": "-",
         "Tactic": "Privilege Escalation",
@@ -1839,6 +1864,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "Abuse Elevation Control Mechanism"
     },
+    "T1548.006": {
+        "Sub-Technique": "TCC Manipulation",
+        "Tactic": "Defense Evasion",
+        "Technique": "Abuse Elevation Control Mechanism"
+    },
     "T1550": {
         "Sub-Technique": "-",
         "Tactic": "Lateral Movement",
@@ -1947,7 +1977,7 @@
     "T1554": {
         "Sub-Technique": "-",
         "Tactic": "Persistence",
-        "Technique": "Compromise Client Software Binary"
+        "Technique": "Compromise Host Software Binary"
     },
     "T1555": {
         "Sub-Technique": "-",
@@ -2026,6 +2056,11 @@
     },
     "T1556.008": {
         "Sub-Technique": "Network Provider DLL",
+        "Tactic": "Credential Access",
+        "Technique": "Modify Authentication Process"
+    },
+    "T1556.009": {
+        "Sub-Technique": "Conditional Access Policies",
         "Tactic": "Credential Access",
         "Technique": "Modify Authentication Process"
     },
@@ -2264,6 +2299,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "Hide Artifacts"
     },
+    "T1564.012": {
+        "Sub-Technique": "File/Path Exclusions",
+        "Tactic": "Defense Evasion",
+        "Technique": "Hide Artifacts"
+    },
     "T1565": {
         "Sub-Technique": "-",
         "Tactic": "Impact",
@@ -2464,6 +2504,11 @@
         "Tactic": "Defense Evasion",
         "Technique": "Hijack Execution Flow"
     },
+    "T1574.014": {
+        "Sub-Technique": "AppDomainManager",
+        "Tactic": "Defense Evasion",
+        "Technique": "Hijack Execution Flow"
+    },
     "T1578": {
         "Sub-Technique": "-",
         "Tactic": "Defense Evasion",
@@ -2584,6 +2629,11 @@
         "Tactic": "Resource Development",
         "Technique": "Compromise Infrastructure"
     },
+    "T1584.008": {
+        "Sub-Technique": "Network Devices",
+        "Tactic": "Resource Development",
+        "Technique": "Compromise Infrastructure"
+    },
     "T1585": {
         "Sub-Technique": "-",
         "Tactic": "Resource Development",
@@ -2681,6 +2731,11 @@
     },
     "T1588.006": {
         "Sub-Technique": "Vulnerabilities",
+        "Tactic": "Resource Development",
+        "Technique": "Obtain Capabilities"
+    },
+    "T1588.007": {
+        "Sub-Technique": "Artificial Intelligence",
         "Tactic": "Resource Development",
         "Technique": "Obtain Capabilities"
     },
@@ -3021,7 +3076,7 @@
     },
     "T1611": {
         "Sub-Technique": "-",
-        "Tactic": "Privilege Escalation",
+        "Tactic": "Defense Evasion",
         "Technique": "Escape to Host"
     },
     "T1612": {
@@ -3111,7 +3166,7 @@
     },
     "T1656": {
         "Sub-Technique": "-",
-        "Tactic": "Defense Evasion",
+        "Tactic": "Lateral Movement",
         "Technique": "Impersonation"
     },
     "T1657": {
@@ -3123,6 +3178,11 @@
         "Sub-Technique": "-",
         "Tactic": "Command and Control",
         "Technique": "Content Injection"
+    },
+    "T1665": {
+        "Sub-Technique": "-",
+        "Tactic": "Command and Control",
+        "Technique": "Hide Infrastructure"
     },
     "TA0001": {
         "Sub-Technique": "-",


### PR DESCRIPTION
## What Changed
Since version 15 of MITER ATT&CK has been released, I have updated the mitre-attack.json.
- https://attack.mitre.org/docs/changelogs/v14.1-v15.0/changelog-detailed.html
- https://medium.com/mitre-attack/attack-v15-26685f300acc

## Test
### Environment
- OS: macOS Sonoma version 14.4.1
- Hayabusa v2.15.0
- Nim: 2.0.2
- nimble: 0.14.2

### Integration-Test
https://github.com/Yamato-Security/takajo/actions/runs/8835001463

### automagic
I confirmed that there is no difference in the automagic command results.
```
fukusuke@fukusukenoAir takajo-2.5.0-mac-arm % ./takajo automagic -t timeline.jsonl -o case-1  #with old json
fukusuke@fukusukenoAir takajo-2.5.0-mac-arm % ./takajo automagic -t timeline.jsonl -o case-2  #with new json
fukusuke@fukusukenoAir takajo-2.5.0-mac-arm % diff case-1/TTPSummary.csv case-2/TTPSummary.csv
fukusuke@fukusukenoAir takajo-2.5.0-mac-arm % diff case-1/MitreTTP-Heatmap.json case-2/MitreTTP-Heatmap.json
fukusuke@fukusukenoAir takajo-2.5.0-mac-arm % 
```

I would appreciate it if you could check it out when you have time🙏