### PR TITLE
fix: define CountTable type explicitly

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,6 +1,6 @@
 # 変更点
 
-## x.x.x [xxxx/xx/xx]
+## 2.6.0 [xxxx/xx/xx]
 
 **改善:**
 
@@ -10,6 +10,7 @@
 **バグ修正:**
 
 - https://github.com/treeform/puppy/issues/118 によるmacOSでのコンパイルエラーを修正した。 (#158) (@YamatoSecurity)
+- Nim 2.0.6でのコンパイルエラーを修正した。 (#162) (@fukusuket)
 
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## x.x.x [xxxx/xx/xx]
+## 2.6.0 [xxxx/xx/xx]
 
 **Enhancements:**
 
@@ -10,6 +10,7 @@
 **Bug Fixes:**
 
 - Fixed a compile error on macOS due to https://github.com/treeform/puppy/issues/118 . (#158) (@YamatoSecurity)
+- Fixed a compile error when using nim 2.0.6. (#162) (@fukusuket)
 
 ## 2.5.0 [2024/03/30] - BSides Tokyo Release
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -90,7 +90,7 @@ when isMainModule:
     const example_vt_hash_lookup = "  vt-hash-lookup -a <API-KEY> --hashList case-1-MD5-hashes.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
     const example_vt_ip_lookup = "  vt-ip-lookup -a <API-KEY> --ipList ipAddresses.txt -r 1000 -o results.csv --jsonOutput responses.json\p"
 
-    clCfg.useMulti = "Version: 2.5.0 BSides Tokyo Release\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
+    clCfg.useMulti = "Version: 2.6.0 Dev Build\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
         examples &
         example_automagic &
         example_extract_scriptblocks &

--- a/src/takajopkg/stackCommon.nim
+++ b/src/takajopkg/stackCommon.nim
@@ -18,8 +18,8 @@ type StackRecord* = ref object
     eid* = ""
     channel* = ""
     levelsOrder* = 0
-    levels*:CountTable = initCountTable[string]()
-    ruleTitles*:CountTable = initCountTable[string]()
+    levels*:CountTable[string] = initCountTable[string]()
+    ruleTitles*:CountTable[string] = initCountTable[string]()
     otherColumn = newSeq[string]()
 
 proc calcLevelOrder(x: StackRecord): int =

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.5.0"
+version       = "2.6.0"
 author        = "Yamato Security @SecurityYamato"
 description   = "Takajo is an analyzer for Hayabusa results."
 license       = "GPL-3.0"


### PR DESCRIPTION
## What Changed
- Closed #162 
   - I could not find any changes from the release notes for Nim `2.0.6` regarding specification changes, but the compilation now passes by specifying the CounTable type.

## Test
### Environment
- OS: macOS Sonoma version 14.5
- Hayabusa v2.17.0-dev
- nimble: 0.14.2

Integration-Test/Release automation succeeded as follows.
- https://github.com/Yamato-Security/takajo/actions/runs/9695155689
- https://github.com/Yamato-Security/takajo/actions/runs/9695128439