### PR TITLE
Update GitHub Actions setup-nim-action@v2

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup Nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: '2.x' # default is 'stable'
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - name: setup Nim
         uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: '2.x' # default is 'stable'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: clone takajo
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: setup Nim
         uses: jiro4989/setup-nim-action@v2
-        with:
-          nim-version: '2.x' # default is 'stable'
 
       - name: clone takajo
         uses: actions/checkout@v4

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.info.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: '2.x' # default is 'stable'
       - name: Build check

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -26,7 +26,7 @@ jobs:
             }
     runs-on: ${{ matrix.info.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: '2.x' # default is 'stable'

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jiro4989/setup-nim-action@v2
-        with:
-          nim-version: '2.x' # default is 'stable'
       - name: Build check
         run: nimble build --threads:on -Y
       - name: Run tests

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: '2.c' # default is 'stable'
+          nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build check
         run: nimble build --threads:on -Y

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -28,6 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: '2.c' # default is 'stable'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build check
         run: nimble build --threads:on -Y
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Setup Nim
         uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: '2.x' # default is 'stable'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update nimble libraries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2
 
       - name: Update nimble libraries
         run: |


### PR DESCRIPTION
## What Changed
Version 2 of setup-nim-actions has been released, so I updated it.
https://github.com/jiro4989/setup-nim-action?tab=readme-ov-file#v2-version-was-released-tada

## Test
#### Integration-Test
- https://github.com/Yamato-Security/takajo/actions/runs/10730617246

#### Takajo Release Automation
- https://github.com/Yamato-Security/takajo/actions/runs/10730557733

I would appreciate it if you could check it out when you have time🙏