### PR TITLE
fix: Release Automation GitHub Actions add copy templates folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
         run: |
           case "${{ matrix.os }}" in
             'windows-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel" >> $GITHUB_OUTPUT ;;
             'ubuntu-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel" >> $GITHUB_OUTPUT ;;
             'macos-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT ;;
             'macos-12')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT ;;
           esac
 
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,6 @@ jobs:
             'macos-12')
                 mv release-binaries/takajo release-binaries/takajo-${{ github.event.inputs.release_ver }}-mac-x64 ;;
           esac
-      - name: Setup node
-        if: matrix.os == 'macos-latest'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
 
       - name: Set Artifact Name
         id: set_artifact_name
@@ -94,6 +89,12 @@ jobs:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: |
             release-binaries/*
+
+      - name: Setup node
+        if: matrix.os == 'macos-latest'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: Create PDF
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
           Copy-Item -Path takajo.exe -Destination release-binaries/
           Copy-Item -Path mitre-attack.json -Destination release-binaries/
           Copy-Item -Path pcre64.dll -Destination release-binaries/
-          Compress-Archive -Path release-binaries/* -DestinationPath release-binaries/takajo-${{ github.event.inputs.release_ver }}-win.zip -Force
+          Copy-Item -Path templates -Destination release-binaries/ -Recurse
+          mv release-binaries takajo-${{ github.event.inputs.release_ver }}-win
+          Compress-Archive -Path takajo-${{ github.event.inputs.release_ver }}-win/* -DestinationPath takajo-${{ github.event.inputs.release_ver }}-win.zip -Force
 
       - name: Package and Zip - Unix
         if: matrix.os != 'windows-latest'
@@ -53,12 +55,18 @@ jobs:
           mkdir -p release-binaries
           cp takajo release-binaries/
           cp mitre-attack.json release-binaries/
+          cp -r templates release-binaries/
           case ${{ matrix.os }} in
-            'ubuntu-latest') zip -j release-binaries/takajo-${{ github.event.inputs.release_ver }}-linux.zip release-binaries/* ;;
-            'macos-latest') zip -j release-binaries/takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip release-binaries/* ;;
-            'macos-12') zip -j release-binaries/takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip release-binaries/* ;;
+            'ubuntu-latest')
+                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-linux
+                zip -r takajo-${{ github.event.inputs.release_ver }}-linux.zip takajo-${{ github.event.inputs.release_ver }}-linux/* ;;
+            'macos-latest')
+                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-arm
+                zip -r takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip takajo-${{ github.event.inputs.release_ver }}-mac-arm/* ;;
+            'macos-12')
+                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-intel
+                zip -r takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip takajo-${{ github.event.inputs.release_ver }}-mac-intel/* ;;
           esac
-
       - name: Setup node
         if: matrix.os == 'macos-latest'
         uses: actions/setup-node@v4
@@ -78,5 +86,5 @@ jobs:
         with:
           name: release-binaries-${{ matrix.os }}
           path: |
-            release-binaries/*.zip
+            **/*.zip
             ./*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,12 @@ jobs:
         run: |
           mkdir -p release-binaries
           Copy-Item -Path takajo.exe -Destination release-binaries/
+          mv release-binaries/takajo.exe release-binaries/takajo-${{ github.event.inputs.release_ver }}-win-x64.exe
           Copy-Item -Path mitre-attack.json -Destination release-binaries/
           Copy-Item -Path pcre64.dll -Destination release-binaries/
           Copy-Item -Path templates -Destination release-binaries/ -Recurse
-          mv release-binaries takajo-${{ github.event.inputs.release_ver }}-win
-          Compress-Archive -Path takajo-${{ github.event.inputs.release_ver }}-win/* -DestinationPath takajo-${{ github.event.inputs.release_ver }}-win.zip -Force
+          mv release-binaries takajo-${{ github.event.inputs.release_ver }}-win-x64
+          Compress-Archive -Path takajo-${{ github.event.inputs.release_ver }}-win-x64/* -DestinationPath takajo-${{ github.event.inputs.release_ver }}-win-x64.zip -Force
 
       - name: Package and Zip - Unix
         if: matrix.os != 'windows-latest'
@@ -63,12 +64,15 @@ jobs:
           case ${{ matrix.os }} in
             'ubuntu-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-linux
+                mv takajo-${{ github.event.inputs.release_ver }}-linux/takajo takajo-${{ github.event.inputs.release_ver }}-linux/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu
                 zip -r takajo-${{ github.event.inputs.release_ver }}-linux.zip takajo-${{ github.event.inputs.release_ver }}-linux/* ;;
             'macos-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-arm
+                mv takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64
                 zip -r takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip takajo-${{ github.event.inputs.release_ver }}-mac-arm/* ;;
             'macos-12')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-intel
+                mv takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo-${{ github.event.inputs.release_ver }}-mac-x64
                 zip -r takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip takajo-${{ github.event.inputs.release_ver }}-mac-intel/* ;;
           esac
       - name: Setup node
@@ -77,6 +81,28 @@ jobs:
         with:
           node-version: 20
 
+      - name: Set Artifact Name
+        id: set_artifact_name
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            'windows-latest')
+              echo "artifact_name=takajo-${{ github.event.inputs.release_ver }}-win-x64" >> $GITHUB_OUTPUT ;;
+            'ubuntu-latest')
+              echo "artifact_name=takajo-${{ github.event.inputs.release_ver }}-linux-intel" >> $GITHUB_OUTPUT ;;
+            'macos-latest')
+              echo "artifact_name=takajo-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT ;;
+            'macos-12')
+              echo "artifact_name=takajo-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Upload Zip Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          path: |
+            **/*.zip
+
       - name: Create PDF
         if: matrix.os == 'macos-latest'
         run: |
@@ -84,26 +110,13 @@ jobs:
           md-to-pdf ./*.md --md-file-encoding utf-8
           mv ./README.pdf ./README-${{ github.event.inputs.release_ver }}-English.pdf
           mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
+          mv ./CHANGELOG.pdf ./CHANGELOG-${{ github.event.inputs.release_ver }}-English.pdf
+          mv ./CHANGELOG-Japanese.pdf ./CHANGELOG-${{ github.event.inputs.release_ver }}-Japanese.pdf
 
-      - name: Set Artifact Name
-        id: set_artifact_name
-        shell: bash
-        run: |
-          case "${{ matrix.os }}" in
-            'windows-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel" >> $GITHUB_OUTPUT ;;
-            'ubuntu-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel" >> $GITHUB_OUTPUT ;;
-            'macos-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT ;;
-            'macos-12')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT ;;
-          esac
-
-      - name: Upload Artifact
+      - name: Upload Document Artifacts
+        if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+          name: documents
           path: |
-            **/*.zip
             ./*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
         run: |
           case "${{ matrix.os }}" in
             'windows-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel.zip" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel" >> $GITHUB_OUTPUT
             'ubuntu-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel.zip" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel" >> $GITHUB_OUTPUT
             'macos-latest')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm" >> $GITHUB_OUTPUT
             'macos-12')
-              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip" >> $GITHUB_OUTPUT
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel" >> $GITHUB_OUTPUT
           esac
 
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,13 +91,13 @@ jobs:
         run: |
           case "${{ matrix.os }}" in
             'windows-latest')
-              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-win-intel.zip" ;;
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-win-intel.zip" >> $GITHUB_OUTPUT
             'ubuntu-latest')
-              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-linux-intel.zip" ;;
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-linux-intel.zip" >> $GITHUB_OUTPUT
             'macos-latest')
-              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip" ;;
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip" >> $GITHUB_OUTPUT
             'macos-12')
-              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip" ;;
+              echo "{artifact_name}=takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip" >> $GITHUB_OUTPUT
           esac
 
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
       release_ver:
         required: true
         default: "2.x.x"
-
+      branch_or_tag:
+        required: true
+        default: "main"
 jobs:
   release:
     runs-on: ${{ matrix.os }}
@@ -17,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch_or_tag }}
 
       - name: Setup Nim
         uses: jiro4989/setup-nim-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,15 +65,12 @@ jobs:
             'ubuntu-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-linux
                 mv takajo-${{ github.event.inputs.release_ver }}-linux/takajo takajo-${{ github.event.inputs.release_ver }}-linux/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu
-                zip -r takajo-${{ github.event.inputs.release_ver }}-linux.zip takajo-${{ github.event.inputs.release_ver }}-linux/* ;;
             'macos-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-arm
                 mv takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64
-                zip -r takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip takajo-${{ github.event.inputs.release_ver }}-mac-arm/* ;;
             'macos-12')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-intel
                 mv takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo-${{ github.event.inputs.release_ver }}-mac-x64
-                zip -r takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip takajo-${{ github.event.inputs.release_ver }}-mac-intel/* ;;
           esac
       - name: Setup node
         if: matrix.os == 'macos-latest'
@@ -101,7 +98,7 @@ jobs:
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: |
-            **/*.zip
+            **/*
 
       - name: Create PDF
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,13 @@ jobs:
           case ${{ matrix.os }} in
             'ubuntu-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-linux
-                mv takajo-${{ github.event.inputs.release_ver }}-linux/takajo takajo-${{ github.event.inputs.release_ver }}-linux/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu
+                mv takajo-${{ github.event.inputs.release_ver }}-linux/takajo takajo-${{ github.event.inputs.release_ver }}-linux/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu ;;
             'macos-latest')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-arm
-                mv takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64
+                mv takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64 ;;
             'macos-12')
                 mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-intel
-                mv takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo-${{ github.event.inputs.release_ver }}-mac-x64
+                mv takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo-${{ github.event.inputs.release_ver }}-mac-x64 ;;
           esac
       - name: Setup node
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,25 @@ jobs:
           mv ./README.pdf ./README-${{ github.event.inputs.release_ver }}-English.pdf
           mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
 
+      - name: Set Artifact Name
+        id: set_artifact_name
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            'windows-latest')
+              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-win-intel.zip" ;;
+            'ubuntu-latest')
+              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-linux-intel.zip" ;;
+            'macos-latest')
+              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-mac-arm.zip" ;;
+            'macos-12')
+              echo "::set-output name=artifact_name::takajo-${{ github.event.inputs.release_ver }}-mac-intel.zip" ;;
+          esac
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-binaries-${{ matrix.os }}
+          name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: |
             **/*.zip
             ./*.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,6 @@ jobs:
           Copy-Item -Path mitre-attack.json -Destination release-binaries/
           Copy-Item -Path pcre64.dll -Destination release-binaries/
           Copy-Item -Path templates -Destination release-binaries/ -Recurse
-          mv release-binaries takajo-${{ github.event.inputs.release_ver }}-win-x64
-          Compress-Archive -Path takajo-${{ github.event.inputs.release_ver }}-win-x64/* -DestinationPath takajo-${{ github.event.inputs.release_ver }}-win-x64.zip -Force
 
       - name: Package and Zip - Unix
         if: matrix.os != 'windows-latest'
@@ -63,14 +61,11 @@ jobs:
           cp -r templates release-binaries/
           case ${{ matrix.os }} in
             'ubuntu-latest')
-                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-linux
-                mv takajo-${{ github.event.inputs.release_ver }}-linux/takajo takajo-${{ github.event.inputs.release_ver }}-linux/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu ;;
+                mv release-binaries/takajo release-binaries/takajo-${{ github.event.inputs.release_ver }}-lin-x64-gnu ;;
             'macos-latest')
-                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-arm
-                mv takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo takajo-${{ github.event.inputs.release_ver }}-mac-arm/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64 ;;
+                mv release-binaries/takajo release-binaries/takajo-${{ github.event.inputs.release_ver }}-mac-aarch64 ;;
             'macos-12')
-                mv release-binaries takajo-${{ github.event.inputs.release_ver }}-mac-intel
-                mv takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo takajo-${{ github.event.inputs.release_ver }}-mac-intel/takajo-${{ github.event.inputs.release_ver }}-mac-x64 ;;
+                mv release-binaries/takajo release-binaries/takajo-${{ github.event.inputs.release_ver }}-mac-x64 ;;
           esac
       - name: Setup node
         if: matrix.os == 'macos-latest'
@@ -98,7 +93,7 @@ jobs:
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: |
-            **/*
+            release-binaries/*
 
       - name: Create PDF
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## What Changed
Related: #184 
- Added coping template folder step
- Added the ability to specify the tag name and branch name to build Takajo  

## Test
Add parameter to allow branch/tag names to be specified as follows.
- `release_ver`: Version number to use for file names
- `branch_or_tag`: Branch or tag name to build takajo
<img width="1062" alt="スクリーンショット 2024-09-08 20 19 20" src="https://github.com/user-attachments/assets/85c4cb07-40ae-424f-bf3e-d70e2a332d48">

Actions succeeded as follows
https://github.com/Yamato-Security/takajo/actions/runs/10759326195

The zip could be downloaded as follows
<img width="841" alt="スクリーンショット 2024-09-08 20 17 18" src="https://github.com/user-attachments/assets/724ffdea-8809-4c7c-958d-b2c1f397de33">

I would appreciate it if you could check it out when you have time🙏