### PR TITLE
feat: add `extract-credentials` command

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -2,6 +2,10 @@
 
 ## 2.7.0 [2024/10/21] SecTor Release
 
+**新機能:**
+
+- `extract-credentials`コマンド: セキュリティ4688とSysmon 1イベントのコマンドライン情報から平文の認証情報を取り出す。例: `wmic`、`schtasks`、`net user`、`psexec`の使用。 (#192) (@fukusuket)
+
 **改善:**
 
 - HTMLレポートのRule SummaryページのTotal DetectionsとUnique Detectionsの検出サマリが1つの表に統合された。(#182) (@nishikawaakira)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.7.0 [2024/10/21] SecTor Release
 
+**New Features:**
+
+`extract-credentials` command: extract out plaintext credentials from the command line information in Security 4688 and Sysmon 1 events. Ex: `wmic`, `schtasks`, `net user`, `psexec` usage. (#192) (@fukusuket)
+
 **Enhancements:**
 
 - Detection summary for Total Detections and Unique Detections in the Rule Summary page of the HTML report has been consolidated into one table. (#182) (@nishikawaakira)

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -123,7 +123,7 @@ when isMainModule:
         ],
         [
             extractCredentials, cmdName = "extract-credentials",
-            doc = "extract credentials from the timeline",
+            doc = "extract plaintext credentials from the command-line auditing",
             help = {
                 "output": "save results to a csv file",
                 "quiet": "do not display the launch banner (default: false)",

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -26,6 +26,7 @@ import takajopkg/takajoCore
 import takajopkg/takajoTerminal
 import takajopkg/ttpResult
 import takajopkg/vtResult
+include takajopkg/extractCredentials
 include takajopkg/extractScriptblocks
 include takajopkg/listDomains
 include takajopkg/listIpAddresses
@@ -62,7 +63,8 @@ when isMainModule:
     clCfg.version = "2.7.0"
     const examples = "Examples:\p"
     const example_automagic = "  automagic -t ../hayabusa/timeline.jsonl [--level low] [--displayTable] -o case-1\p"
-    const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low] -o scriptblock-logs\p"
+    const example_extract_credentials = "  extract-credentials -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o credentials.csv\p"
+    const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low]  [--skipProgressBar] -o scriptblock-logs\p"
     const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o domains.txt\p"
     const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl [--skipProgressBar] -o case-1\p"
     const example_list_ip_addresses = "  list-ip-addresses -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o ipAddresses.txt\p"
@@ -95,7 +97,7 @@ when isMainModule:
     clCfg.useMulti = "Version: 2.7.0 Dev Build\pUsage: takajo.exe <COMMAND>\p\pCommands:\p$subcmds\pCommand help: $command help <COMMAND>\p\p" &
         examples &
         example_automagic &
-        example_extract_scriptblocks & example_html_report &
+        example_extract_credentials & example_extract_scriptblocks & example_html_report &
         example_list_domains & example_list_hashes & example_list_ip_addresses & example_list_undetected_evtx & example_list_unused_rules &
         example_split_csv_timeline & example_split_json_timeline &
         example_stack_cmdlines & example_stack_computers & example_stack_dns & example_stack_ip_addresses & example_stack_logons & example_stack_processes & example_stack_services & example_stack_tasks & example_stack_users &
@@ -114,6 +116,16 @@ when isMainModule:
                 "displayTable": "display the results table (default: false)",
                 "level": "specify the minimum alert level (default: informational)",
                 "output": "output directory (default: case-1)",
+                "quiet": "do not display the launch banner (default: false)",
+                "skipProgressBar": "do not display the progress bar (default: false)",
+                "timeline": "Hayabusa JSONL timeline file or directory (profile: any)",
+            }
+        ],
+        [
+            extractCredentials, cmdName = "extract-credentials",
+            doc = "extract credentials from the timeline",
+            help = {
+                "output": "save results to a csv file",
                 "quiet": "do not display the launch banner (default: false)",
                 "skipProgressBar": "do not display the progress bar (default: false)",
                 "timeline": "Hayabusa JSONL timeline file or directory (profile: any)",

--- a/src/takajopkg/extractCredentials.nim
+++ b/src/takajopkg/extractCredentials.nim
@@ -48,6 +48,8 @@ method analyze*(self: ExtractCredentialsCmd, x: HayabusaJson) =
   singleResultTable["Event"] = x.Channel & "-" & $(x.EventID)
   let cmd = x.Details["Cmdline"].getStr()
   let (user, pass) = extractUserPass(cmd)
+  if user == "" and pass == "":
+    return # skip if no user or password found
   singleResultTable["User"] = user
   singleResultTable["Password"] = pass
   singleResultTable["API Key"] = "N/A"

--- a/src/takajopkg/extractCredentials.nim
+++ b/src/takajopkg/extractCredentials.nim
@@ -52,14 +52,13 @@ method analyze*(self: ExtractCredentialsCmd, x: HayabusaJson) =
     return # skip if no user or password found
   singleResultTable["User"] = user
   singleResultTable["Password"] = pass
-  singleResultTable["API Key"] = "N/A"
   singleResultTable["Cmdline"] = cmd
   self.seqOfResultsTables.add(singleResultTable)
 
 method resultOutput*(self: ExtractCredentialsCmd) =
   var savedFiles = "n/a"
   var results = "n/a"
-  let header = ["Timestamp", "Computer", "Event", "User", "Password", "API Key", "Cmdline"]
+  let header = ["Timestamp", "Computer", "Event", "User", "Password", "Cmdline"]
   if self.output != "":
     # Open file to save results
     var outputFile = open(self.output, fmWrite)
@@ -89,7 +88,7 @@ method resultOutput*(self: ExtractCredentialsCmd) =
     var table: TerminalTable
     table.add header
     for t in self.seqOfResultsTables:
-      table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]], t[header[6]]
+      table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]]
     if self.displayTable:
       echo ""
       table.echoTableSepsWithStyled(seps = boxSeps)

--- a/src/takajopkg/extractCredentials.nim
+++ b/src/takajopkg/extractCredentials.nim
@@ -1,5 +1,5 @@
 const ExtractCredentialsMsg =
-  """This command extracts credentials from command lines in Sysmon and Security event logs."""
+  """This command extracts plaintext credentials from command-lines in Sysmon 1 and Security 4688 event logs."""
 
 type
   ExtractCredentialsCmd* = ref object of AbstractCmd

--- a/src/takajopkg/extractCredentials.nim
+++ b/src/takajopkg/extractCredentials.nim
@@ -1,0 +1,107 @@
+const ExtractCredentialsMsg =
+  """This command extracts credentials from command lines in Sysmon and Security event logs."""
+
+type
+  ExtractCredentialsCmd* = ref object of AbstractCmd
+    seqOfResultsTables*: seq[Table[string, string]]
+
+method filter*(self: ExtractCredentialsCmd, x: HayabusaJson): bool =
+  let eidMatched = (x.EventID == 1 and x.Channel == "Sysmon") or (x.EventID == 4688 and x.Channel == "Sec")
+  if not eidMatched:
+    return false
+  let cmdline = x.Details["Cmdline"].getStr().toLower()
+  let commands = ["net user", "schtasks", "wmic", "psexec"]
+  let cmdMatched = any(commands, proc(x: string): bool = x in cmdline)
+  if "net user" in cmdline:
+    return true # net user does not have password parameter
+  let passwordPram = ["-p", "-password", "-passwd", "–password", "–passwd", "/p", "/password", "/passwd"]
+  let passwordMatched = any(passwordPram, proc(x: string): bool = x in cmdline)
+  return cmdMatched and passwordMatched
+
+proc extractUserPass(cmd: string): (string, string) =
+    let patterns = [
+      (re(r".*/user:([^\s/]+).*"), re(r".*/password:([^\s/]+).*")),  # for wmic
+      (re(r".*/U ([^\s/]+).*"), re(r".*/P ([^\s/]+).*")),  # for schtasks
+      (re(r".*net user ([^\s/]+)"), re(r".*?([^\s/]+) /add.*")),  # for net user
+      (re(r".*-u ([^\s/]+).*"), re(r".*-p ([^\s/]+).*"))  # for psexec
+    ]
+
+    for (userPattern, passwordPattern) in patterns:
+      var username = ""
+      var password = ""
+
+      if cmd =~ userPattern:
+        username = matches[0]
+
+      if cmd =~ passwordPattern:
+        password = matches[0]
+
+      if username != "" and password != "":
+        return (username, password)
+
+    return ("", "")
+
+method analyze*(self: ExtractCredentialsCmd, x: HayabusaJson) =
+  var singleResultTable = initTable[string, string]()
+  singleResultTable["Timestamp"] = x.Timestamp
+  singleResultTable["Computer"] = x.Computer
+  singleResultTable["Event"] = x.Channel & "-" & $(x.EventID)
+  let cmd = x.Details["Cmdline"].getStr()
+  let (user, pass) = extractUserPass(cmd)
+  singleResultTable["User"] = user
+  singleResultTable["Password"] = pass
+  singleResultTable["API Key"] = "N/A"
+  singleResultTable["Cmdline"] = cmd
+  self.seqOfResultsTables.add(singleResultTable)
+
+method resultOutput*(self: ExtractCredentialsCmd) =
+  var savedFiles = "n/a"
+  var results = "n/a"
+  let header = ["Timestamp", "Computer", "Event", "User", "Password", "API Key", "Cmdline"]
+  if self.output != "":
+    # Open file to save results
+    var outputFile = open(self.output, fmWrite)
+
+    ## Write CSV header
+    outputFile.write(header.join(",") & "\p")
+
+    ## Write contents
+    for table in self.seqOfResultsTables:
+      for i, key in enumerate(header):
+        if table.hasKey(key):
+          if i < header.len() - 1:
+            outputFile.write(escapeCsvField(table[key]) & ",")
+          else:
+            outputFile.write(escapeCsvField(table[key]))
+        else:
+          outputFile.write(",")
+      outputFile.write("\p")
+    outputFile.close()
+    let fileSize = getFileSize(self.output)
+    savedFiles = self.output & " (" & formatFileSize(fileSize) & ")"
+    results = "Events: " & intToStr(self.seqOfResultsTables.len).insertSep(',')
+    if self.displayTable:
+      echo ""
+      echo "Saved results to " & savedFiles
+  else:
+    var table: TerminalTable
+    table.add header
+    for t in self.seqOfResultsTables:
+      table.add t[header[0]], t[header[1]], t[header[2]], t[header[3]], t[header[4]], t[header[5]], t[header[6]]
+    if self.displayTable:
+      echo ""
+      table.echoTableSepsWithStyled(seps = boxSeps)
+      echo ""
+  self.cmdResult = CmdResult(results: results, savedFiles: savedFiles)
+
+proc extractCredentials(output: string = "", quiet: bool = false, skipProgressBar: bool = false, timeline: string) =
+  checkArgs(quiet, timeline, "informational")
+  var filePaths = getTargetExtFileLists(timeline, ".jsonl", true)
+  for timelinePath in filePaths:
+    let cmd = ExtractCredentialsCmd(
+                timeline: timelinePath,
+                skipProgressBar: skipProgressBar,
+                output: output,
+                name: "extract-credentials",
+                msg: ExtractCredentialsMsg)
+    cmd.analyzeJSONLFile()

--- a/src/takajopkg/takajoCore.nim
+++ b/src/takajopkg/takajoCore.nim
@@ -61,7 +61,8 @@ proc analyzeJSONLFile*(self: AbstractCmd, cmds: seq[AbstractCmd] = newSeq[
         try:
           if cmd.filter(jsonLine):
             cmd.analyze(jsonLine)
-        except CatchableError:
+        except CatchableError as e:
+          echo "An error occurred: ", e.msg
           continue
 
   if not self.skipProgressBar:


### PR DESCRIPTION
## What Changed
- Closed #188 
- Extract the password from the following command line
  - wmic
  - schtasks
  - net user
  - psexec

## help
```
% ./takajo
┏━━━━┳━━━┳┓┏━┳━━━┓ ┏┳━━━┓
┃┏┓┏┓┃┏━┓┃┃┃┏┫┏━┓┃ ┃┃┏━┓┃
┗┛┃┃┗┫┃ ┃┃┗┛┛┃┃ ┃┃ ┃┃┃ ┃┃
  ┃┃ ┃┗━┛┃┏┓┓┃┗━┛┣┓┃┃┃ ┃┃
  ┃┃ ┃┏━┓┃┃┃┗┫┏━┓┃┗┛┃┗━┛┃
  ┗┛ ┗┛ ┗┻┛┗━┻┛ ┗┻━━┻━━━┛
  by Yamato Security

Version: 2.7.0 Dev Build
Usage: takajo.exe <COMMAND>

Commands:
  help                           print comprehensive or per-cmd help
  automagic                      automatically executes as many commands as possible and output results to a new folder
  extract-credentials            extract credentials from the timeline
...
Examples:
  automagic -t ../hayabusa/timeline.jsonl [--level low] [--displayTable] -o case-1
  extract-credentials -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o credentials.csv
  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low]  [--skipProgressBar] -o scriptblock-logs
...
```

## terminal output
I checked https://github.com/Yamato-Security/takajo/issues/188#issuecomment-2381252863 commands. (I have not been able to confirm this because the wmic command line was not recorded in my environment...)
```
% ./takajo extract-credentials -t timeline.jsonl -q
Started the extract-credentials command

This command extracts credentials from command lines in Sysmon and Security event logs.

Counting total lines. Please wait.

File: timeline.jsonl (16.35 KB)
Total lines: 20

Scanning the Hayabusa timeline. Please wait.

100%|█████████████████████████| 20/20 [ 0.0s< 0.0s,  43.31k/sec]

┌────────────────────────────────┬──────────┬──────────┬────────────┬──────────────┬─────────┬────────────────────────────────────────────────┐
│ Timestamp                      │ Computer │ Event    │ User       │ Password     │ API Key │ Cmdline                                        │
├────────────────────────────────┼──────────┼──────────┼────────────┼──────────────┼─────────┼────────────────────────────────────────────────┤
│ 2024-09-30 07:45:32.793 +09:00 │ win10    │ Sysmon-1 │ vagrant    │ vagrant      │ N/A     │ schtasks /Create /S dc /U vagrant /P vagrant   │
│                                │          │          │            │              │         │ /SC DAILY /TN MyScheculeTask /TR               │
│                                │          │          │            │              │         │ C:/Path/To/MyScript.vbs /ST 14:00              │
├────────────────────────────────┼──────────┼──────────┼────────────┼──────────────┼─────────┼────────────────────────────────────────────────┤
│ 2024-09-30 07:45:46.608 +09:00 │ win10    │ Sysmon-1 │ testuser   │ Password!#@$ │ N/A     │ net user testuser Password!#@$ /add            │
├────────────────────────────────┼──────────┼──────────┼────────────┼──────────────┼─────────┼────────────────────────────────────────────────┤
│ 2024-09-30 07:46:09.193 +09:00 │ win10    │ Sysmon-1 │ vagrant@dc │ vagrant      │ N/A     │ psexec \\dc -u vagrant@dc -p vagrant           │
│                                │          │          │            │              │         │ systeminfo                                     │
└────────────────────────────────┴──────────┴──────────┴────────────┴──────────────┴─────────┴────────────────────────────────────────────────┘


Elapsed time: 0 hours, 0 minutes, 0 seconds
```

## csv output
I checked https://github.com/Yamato-Security/takajo/issues/188#issuecomment-2381252863 commands. (I have not been able to confirm this because the wmic command line was not recorded in my environment...)
```
% ./takajo extract-credentials -t timeline.jsonl -q -o credentials.csv
Started the extract-credentials command

This command extracts credentials from command lines in Sysmon and Security event logs.

Counting total lines. Please wait.

File: timeline.jsonl (16.35 KB)
Total lines: 20

Scanning the Hayabusa timeline. Please wait.

100%|█████████████████████████| 20/20 [ 0.0s< 0.0s,  43.55k/sec]

Saved results to credentials.csv (458 Bytes)

Elapsed time: 0 hours, 0 minutes, 0 seconds

fukusuke@fukusukenoMacBook-Air takajo-2.6.0-mac-arm % cat credentials.csv
Timestamp,Computer,Event,User,Password,API Key,Cmdline
2024-09-30 07:45:32.793 +09:00,win10,Sysmon-1,vagrant,vagrant,N/A,schtasks /Create /S dc /U vagrant /P vagrant /SC DAILY /TN MyScheculeTask /TR C:/Path/To/MyScript.vbs /ST 14:00
2024-09-30 07:45:46.608 +09:00,win10,Sysmon-1,testuser,Password!#@$,N/A,net user testuser Password!#@$ /add
2024-09-30 07:46:09.193 +09:00,win10,Sysmon-1,vagrant@dc,vagrant,N/A,psexec \\dc -u vagrant@dc -p vagrant systeminfo
```

I would appreciate it if you could check it out when you have time🙏