### PR TITLE
fix: win release zip folder level

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,9 @@ jobs:
           ls -lR all-packages
           cd all-packages
           for dir in */; do
-            zip -r "${dir%/}.zip" "$dir"
+            cd "$dir"
+            zip -r "../${dir%/}.zip" *
+            cd ..
           done
       - name: Upload Zip Artifacts(all-packages)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What Changed
- Closed #213 

## Test
### Takajo Release Automation
https://github.com/Yamato-Security/takajo/actions/runs/11751351964

![error](https://github.com/user-attachments/assets/79093d14-eda7-4fc8-b23f-78c22d0b1beb)

I would appreciate it if you could check it out when you have time🙏
