### PR TITLE
feat: add RDP Logon/Logoff to `timeline-logon`

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -1,5 +1,11 @@
 # 変更点
 
+## x.x.x [xxxx/xx/xx]
+
+**改善:**
+
+- RDPログオンとログオフの情報が`timeline-logon`タイムラインに追加された。 #209 (@fukusuket)
+
 ## 2.7.1 [2024/10/31] Halloween Release
 
 **バグ修正:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## x.x.x [xxxx/xx/xx]
+
+**Enhancements:**
+
+- RDP logon and logoff information has been added to the `timeline-logon` timeline. #209 (@fukusuket)
+
 ## 2.7.1 [2024/10/31] Halloween Release
 
 **Bug Fixes:**


### PR DESCRIPTION
## What Changed
- Closed #209 
- Added Rules to Timeline
    -  https://github.com/Yamato-Security/hayabusa-rules/blob/main/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_21_Info_RDP-Logon.yml
    - https://github.com/Yamato-Security/hayabusa-rules/blob/main/hayabusa/builtin/TerminalServices-LocalSessionManager_Op/LocalSessManager_23_Info_RDP-Logoff.yml
- SessionID is used to link Logon and Logoff events

## Test
### Integration-Test
https://github.com/Yamato-Security/takajo/actions/runs/11984876447

### Release Automation
https://github.com/Yamato-Security/takajo/actions/runs/11984887843

I would appreciate it if you could check it out when you have time🙏