### PR TITLE
fix: html-server requires you to reparse JSONL file each run

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -5,6 +5,7 @@
 **改善:**
 
 - `ttp-visualize-sigma`と`ttp-visualize`コマンドのため、MITRE ATT&CKデータをv17に更新した。 (#247) (@fukusuket)
+- `html-server`コマンドを複数回実行しても、JSONLタイムラインを再分析する必要はない。 (#232)(@nishikawaakira)
 
 ## 2.9.2 [2025/04/12] - Sakura Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Enhancements:**
 
 - MITRE ATT&CK data updated to v17 for `ttp-visualize-sigma` and `ttp-visualize` commands. (#247) (@fukusuket)
+- You don't need to reanalyze the JSONL timeline when running `html-server` command multiple times. (#232)(@nishikawaakira)
 
 ## 2.9.2 [2025/04/12] - Sakura Release
 

--- a/src/takajopkg/web/htmlServer.nim
+++ b/src/takajopkg/web/htmlServer.nim
@@ -28,8 +28,18 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
         styledEcho(fgGreen, outputLogo())
 
     if fileExists(sqliteoutput) and clobber == false:
-        echo sqliteoutput & " already exists. Please add the -C, --clobber option to overwrite the file."
-        return false
+        # echo sqliteoutput & " already exists. Please add the -C, --clobber option to overwrite the file."
+        echo sqliteoutput & " already exists. It looks like you have already processed the JSONL file. Do you want to use this file (Y/n):"
+        
+        while true:
+            let input = stdin.readLine().strip()
+            if input.toLowerAscii() == "y":
+                break
+            elif input.toLowerAscii() == "n":
+                return false
+            else:
+                echo "無効な入力です"
+        
 
     # create sqlite file or open exist database file.
     let db = open(sqliteoutput, "", "", "")

--- a/src/takajopkg/web/htmlServer.nim
+++ b/src/takajopkg/web/htmlServer.nim
@@ -28,17 +28,16 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
         styledEcho(fgGreen, outputLogo())
 
     if fileExists(sqliteoutput) and clobber == false:
-        # echo sqliteoutput & " already exists. Please add the -C, --clobber option to overwrite the file."
         echo sqliteoutput & " already exists. It looks like you have already processed the JSONL file. Do you want to use this file (Y/n):"
         
         while true:
             let input = stdin.readLine().strip()
             if input.toLowerAscii() == "y":
-                break
+                return true # use already sqlite file
             elif input.toLowerAscii() == "n":
-                return false
+                break # create new sqlite file
             else:
-                echo "無効な入力です"
+                echo "Invalid input"
         
 
     # create sqlite file or open exist database file.


### PR DESCRIPTION
#232 fix html-server requires you to reparse JSONL file each run.

If the file already exists, the following message is displayed.
```html-report.sqlite already exists. It looks like you have already processed the JSONL file. Do you want to use this file (Y/n): ```

If Y: use html-report.sqlite
<img width="896" alt="Screenshot 2025-04-29 at 11 02 09" src="https://github.com/user-attachments/assets/7dbc7dc1-bbff-41ef-9a08-721c77e0e8eb" />

If n: overwrite html-report.sqlite
<img width="896" alt="Screenshot 2025-04-29 at 11 02 33" src="https://github.com/user-attachments/assets/0b14a6f0-c51c-4482-a69a-6464b79eb343" />
