### PR TITLE
fix: vt-ip-lookup result vt link

### DIFF
--- a/CHANGELOG-Japanese.md
+++ b/CHANGELOG-Japanese.md
@@ -7,6 +7,10 @@
 - `html-server`レポートの可読性を改善した。 (#204) (@nishikawaakira)
 - ルールリンクをクリックすると、Sigmaルールがブラウザに表示されるようになった。 (#257) (@nishikawaakira)
 
+**バグ修正:**
+
+- `vt-ip-lookup`コマンドの結果のURLリンクが間違っていました。 (#259) (@fukusuket)
+
 ## 2.10.0 [2025/05/20] - AUSCERT/SINCON Release
 
 **改善:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Improved readability in the `html-server` report. (#204) (@nishikawaakira)
 - Sigma rules are now displayed in the browser if you click on the link. (#257) (@nishikawaakira)
 
+**Bug Fixes:**
+
+- The URL link in the result of the `vt-ip-lookup` command was incorrect. (#259) (@fukusuket)
+
 ## 2.10.0 [2025/05/20] - AUSCERT/SINCON Release
 
 **Enhancements:**

--- a/src/takajopkg/vtIpLookup.nim
+++ b/src/takajopkg/vtIpLookup.nim
@@ -5,7 +5,7 @@ proc queryIpAPI(ipAddress:string, headers: httpheaders.HttpHeaders, results: ptr
     var jsonResponse = %* {}
     var singleResultTable = newTable[string, string]()
     singleResultTable["IP-Address"] = ipAddress
-    singleResultTable["Link"] = "https://www.virustotal.com/gui/ip_addresses/" & ipAddress
+    singleResultTable["Link"] = "https://www.virustotal.com/gui/ip-address/" & ipAddress
     singleResultTable["Response"] = intToStr(response.code)
     if response.code == 200:
         jsonResponse = parseJson(response.body)


### PR DESCRIPTION
## What Changed
- Closed #259 

## Evidence

```
% ./takajo vt-ip-lookup -a <api-key> --ipList ipAddresses.txt -o results.csv
```

```
 % cat results.csv
Response,IP-Address,SSL-CommonName,SSL-IssuerCountry,LastAnalysisDate,LastModifiedDate,LastHTTPSCertDate,LastWhoisDate,MaliciousCount,HarmlessCount,SuspiciousCount,UndetectedCount,CommunityVotesHarmless,CommunityVotesMalicious,Reputation,RegionalInternetRegistry,Network,Country,AS-Owner,SSL-ValidAfter,SSL-ValidUntil,SSL-Issuer,WhoisInfo,Link,
200,192.168.0.1,Unknown,Unknown,2025-06-30 08:13:08,2025-06-30 10:57:55,Unknown,2022-11-14 16:54:10,0,62,0,32,43,17,-9,Unknown,Unknown,Unknown,Unknown,Unknown,Unknown,Unknown,"NetRange: 192.168.0.0 - 192.168.255.255
CIDR: 192.168.0.0/16
NetName: PRIVATE-ADDRESS-CBLK-RFC1918-IANA-RESERVED
NetHandle: NET-192-168-0-0-1
Parent: NET192 (NET-192-0-0-0-0)
NetType: IANA Special Use
OriginAS:
Organization: Internet Assigned Numbers Authority (IANA)
RegDate: 1994-03-15
Updated: 2013-08-30
Comment: These addresses are in use by many millions of independently operated networks, which might be as small as a single computer connected to a home gateway, and are automatically configured in hundreds of millions of devices. They are only intended for use within a private context and traffic that needs to cross the Internet will need to use a different, unique address.
Comment:
Comment: These addresses can be used by anyone without any need to coordinate with IANA or an Internet registry. The traffic from these addresses does not come from ICANN or IANA. We are not the source of activity you may see on logs or in e-mail records. Please refer to http://www.iana.org/abuse/answers
Comment:
Comment: These addresses were assigned by the IETF, the organization that develops Internet protocols, in the Best Current Practice document, RFC 1918 which can be found at:
Comment: http://datatracker.ietf.org/doc/rfc1918
Ref: https://rdap.arin.net/registry/ip/192.168.0.0
OrgName: Internet Assigned Numbers Authority
OrgId: IANA
Address: 12025 Waterfront Drive
Address: Suite 300
City: Los Angeles
StateProv: CA
PostalCode: 90292
Country: US
RegDate:
Updated: 2012-08-31
Ref: https://rdap.arin.net/registry/entity/IANA
OrgAbuseHandle: IANA-IP-ARIN
OrgAbuseName: ICANN
OrgAbusePhone: +1-310-301-5820
OrgAbuseEmail: abuse@iana.org
OrgAbuseRef: https://rdap.arin.net/registry/entity/IANA-IP-ARIN
OrgTechHandle: IANA-IP-ARIN
OrgTechName: ICANN
OrgTechPhone: +1-310-301-5820
OrgTechEmail: abuse@iana.org
OrgTechRef: https://rdap.arin.net/registry/entity/IANA-IP-ARIN
",https://www.virustotal.com/gui/ip-address/192.168.0.1,
```

I’d appreciate it if you could check it when you have time🙏