### PR TITLE
feat: add DuckDB as default database backend with SQLite fallback

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -45,8 +45,6 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
           Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
-          Copy-Item duckdb_lib\duckdb.h -Destination duckdb_lib\
-          Copy-Item duckdb_lib\duckdb.lib -Destination duckdb_lib\
           Copy-Item duckdb_lib\duckdb.dll -Destination .
       - name: Build check
         run: nimble build --threads:on -Y

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -45,8 +45,8 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
           Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
-          Copy-Item duckdb_lib\duckdb.h -Destination C:\ProgramData\nim\lib\
-          Copy-Item duckdb_lib\duckdb.lib -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.h -Destination duckdb_lib\
+          Copy-Item duckdb_lib\duckdb.lib -Destination duckdb_lib\
           Copy-Item duckdb_lib\duckdb.dll -Destination .
       - name: Build check
         run: nimble build --threads:on -Y

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -31,6 +31,23 @@ jobs:
         with:
           nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install DuckDB (Ubuntu)
+        if: matrix.info.os == 'ubuntu-latest'
+        run: |
+          wget -q https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-linux-amd64.zip
+          unzip -o libduckdb-linux-amd64.zip -d duckdb_lib
+          sudo cp duckdb_lib/duckdb.h /usr/local/include/
+          sudo cp duckdb_lib/libduckdb.so /usr/local/lib/
+          sudo ldconfig
+      - name: Install DuckDB (Windows)
+        if: matrix.info.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
+          Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
+          Copy-Item duckdb_lib\duckdb.h -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.lib -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.dll -Destination .
       - name: Build check
         run: nimble build --threads:on -Y
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,8 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
           Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
-          Copy-Item duckdb_lib\duckdb.h -Destination C:\ProgramData\nim\lib\
-          Copy-Item duckdb_lib\duckdb.lib -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.h -Destination duckdb_lib\
+          Copy-Item duckdb_lib\duckdb.lib -Destination duckdb_lib\
           Copy-Item duckdb_lib\duckdb.dll -Destination .
 
       - name: Install DuckDB (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
         run: |
           Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
           Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
-          Copy-Item duckdb_lib\duckdb.h -Destination duckdb_lib\
-          Copy-Item duckdb_lib\duckdb.lib -Destination duckdb_lib\
           Copy-Item duckdb_lib\duckdb.dll -Destination .
 
       - name: Install DuckDB (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,30 @@ jobs:
           nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install DuckDB (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          wget -q https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-linux-amd64.zip
+          unzip -o libduckdb-linux-amd64.zip -d duckdb_lib
+          sudo cp duckdb_lib/duckdb.h /usr/local/include/
+          sudo cp duckdb_lib/libduckdb.so /usr/local/lib/
+          sudo ldconfig
+
+      - name: Install DuckDB (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip" -OutFile duckdb.zip
+          Expand-Archive -Path duckdb.zip -DestinationPath duckdb_lib
+          Copy-Item duckdb_lib\duckdb.h -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.lib -Destination C:\ProgramData\nim\lib\
+          Copy-Item duckdb_lib\duckdb.dll -Destination .
+
+      - name: Install DuckDB (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install duckdb
+
       - name: Update nimble libraries
         run: |
           nimble update

--- a/README-Japanese.md
+++ b/README-Japanese.md
@@ -169,6 +169,28 @@ Takajōは、日本語で["鷹狩りのスキルに優れた人"](https://en.wik
 
 > ※ 64ビットのWindows、IntelおよびArmベースのmacOS用のリリースバイナリを提供していますが、Linux用のMUSLバイナリを提供することは現時点では困難なため、Linuxには提供していません。
 
+## 必要条件
+
+`html-report`と`html-server`コマンドは、高速な分析クエリのためにデフォルトで[DuckDB](https://duckdb.org/)をデータベースバックエンドとして使用します。
+これらのコマンドを使用する前にDuckDBをインストールする必要があります。
+DuckDBをインストールしたくない場合は、`--sqlite`フラグを使用してSQLiteを代わりに使用できます。
+
+### macOS (Homebrew)
+
+```
+brew install duckdb
+```
+
+### Windows (winget)
+
+```
+winget install DuckDB.cli
+```
+
+### Linux
+
+[DuckDBインストールガイド](https://duckdb.org/docs/installation/)を参照してください。
+
 ## Gitクローン
 
 以下の`git clone`コマンドでレポジトリをダウンロードし、ソースコードからコンパイルして使用することも可能です：
@@ -180,6 +202,7 @@ Takajōは、日本語で["鷹狩りのスキルに優れた人"](https://en.wik
 ## アドバンス: ソースコードからのコンパイル（任意）
 
 まず、[choosenim](https://github.com/nim-lang/choosenim)でNimをインストールして下さい。
+また、コンパイル時にDuckDBのCライブラリが必要なため、DuckDBもインストールしてください（[必要条件](#必要条件)を参照）。
 その後、以下のコマンドでソースコードからコンパイルできます:
 
 ```
@@ -329,7 +352,7 @@ takajo.exe extract-scriptblocks -t ../hayabusa/timeline.jsonl
 ### `html-report`コマンド
 
 ルールと検出されたコンピュータのHTMLサマリレポートを作成します。
-このコマンドは、サマリレポートの作成に必要なデータの高速検索を実行するために、まずインデックス化されたSQLiteデータベースファイルを作成します。
+このコマンドは、サマリレポートの作成に必要なデータの高速検索を実行するために、まずインデックス化されたDuckDBデータベースファイル（デフォルト）またはSQLiteデータベースファイルを作成します。
 
 * 入力: JSONL
 * プロファイル: `verbose`/`super-verbose`プロファイル
@@ -343,10 +366,11 @@ takajo.exe extract-scriptblocks -t ../hayabusa/timeline.jsonl
 
 任意オプション:
 
-- `-C, --clobber`: 保存時にSQLiteファイルを上書きする (デフォルト: `false`)
+- `-C, --clobber`: 保存時にデータベースファイルを上書きする (デフォルト: `false`)
 - `-q, --quiet`: ロゴを出力しない (デフォルト: `false`)
-- `-s, --skipProgressBar`: プログレスバーを出力しない (デフォルト: `false`)
-- `-s, --sqliteoutput`: 結果をSQLiteデータベースに保存する (デフォルト: `html-report.sqlite`)
+- `-s, --dboutput`: 結果をデータベースファイルに保存する (デフォルト: `html-report.duckdb`、`--sqlite`指定時は`html-report.sqlite`)
+- `--skipProgressBar`: プログレスバーを出力しない (デフォルト: `false`)
+- `--sqlite`: DuckDBの代わりにSQLiteバックエンドを使用する (デフォルト: `false`)
 
 #### `html-report`コマンドの使用例
 
@@ -385,7 +409,7 @@ takajo.exe html-report -t ../hayabusa/hayabusa-results.jsonl -o htmlreport -r ..
 ### `html-server`コマンド
 
 HTMLサマリレポートを確認するために、動的にウェブサーバを立ち上げます。
-このコマンドは、サマリレポートの作成に必要なデータの高速検索を実行するために、まずインデックス化されたSQLiteデータベースファイルを作成します。
+このコマンドは、サマリレポートの作成に必要なデータの高速検索を実行するために、まずインデックス化されたDuckDBデータベースファイル（デフォルト）またはSQLiteデータベースファイルを作成します。
 `html-report`コマンドと似ていますが、よりスケーラブルで日付やルールのフィルタリングが可能です。
 
 * 入力: JSONL
@@ -398,12 +422,13 @@ HTMLサマリレポートを確認するために、動的にウェブサーバ�
 
 任意オプション:
 
-- `-C, --clobber`: 保存時にSQLiteファイルを上書きする (デフォルト: `false`)
-- `-p, --port`: ウェブサーバのポート番号
+- `-C, --clobber`: 保存時にデータベースファイルを上書きする (デフォルト: `false`)
+- `-p, --port`: ウェブサーバのポート番号 (デフォルト: `8823`)
 - `-q, --quiet`: ロゴを出力しない (デフォルト: `false`)
 - `-r, --rulepath`: Hayabusaルールディレクトリへのパス (※必須ではないが、ルールファイルへのリンクを作成するために必要。）)
-- `-s, --skipProgressBar`: プログレスバーを出力しない (デフォルト: `false`)
-- `-s, --sqliteoutput`: 結果をSQLiteデータベースに保存する (デフォルト: `html-report.sqlite`)
+- `-s, --dboutput`: 結果をデータベースファイルに保存する (デフォルト: `html-report.duckdb`、`--sqlite`指定時は`html-report.sqlite`)
+- `--skipProgressBar`: プログレスバーを出力しない (デフォルト: `false`)
+- `--sqlite`: DuckDBの代わりにSQLiteバックエンドを使用する (デフォルト: `false`)
 
 #### `html-server` command example
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,28 @@ Please download the latest stable version of Takajo with compiled binaries or co
 
 > Note: we provide release binaries for 64-bit Windows and Intel and Arm-based macOS but not Linux because it is difficult to provide MUSL binaries for Linux at the moment.
 
+## Requirements
+
+The `html-report` and `html-server` commands use [DuckDB](https://duckdb.org/) as the default database backend for fast analytical queries.
+You need to install DuckDB before using these commands.
+You can use the `--sqlite` flag to use SQLite instead if you do not want to install DuckDB.
+
+### macOS (Homebrew)
+
+```
+brew install duckdb
+```
+
+### Windows (winget)
+
+```
+winget install DuckDB.cli
+```
+
+### Linux
+
+Please refer to the [DuckDB installation guide](https://duckdb.org/docs/installation/).
+
 ## Git cloning
 
 You can git clone the repository with the following command and compile binary from source code:
@@ -178,6 +200,7 @@ You can git clone the repository with the following command and compile binary f
 ## Advanced: Compiling From Source (Optional)
 
 First, install Nim with [choosenim](https://github.com/nim-lang/choosenim).
+You also need to install DuckDB (see [Requirements](#requirements)) since the DuckDB C library is required at compile time.
 Then you can compile from source with the following command:
 
 ```
@@ -331,7 +354,7 @@ takajo.exe extract-scriptblocks -t ../hayabusa/timeline.jsonl
 ### `html-report` command
 
 Create HTML summary reports for rules and computers with detections.
-This command first creates an indexed SQLite database file in order to perform fast lookups on the data needed to create the summary reports.
+This command first creates an indexed DuckDB database file (default) or SQLite database file in order to perform fast lookups on the data needed to create the summary reports.
 
 * Input: JSONL
 * Profile: Any verbose profile
@@ -345,10 +368,11 @@ Required options:
 
 Options:
 
-- `-C, --clobber`: overwrite the SQLite file when saving (default: `false`)
+- `-C, --clobber`: overwrite the database file when saving (default: `false`)
 - `-q, --quiet`: do not display the launch banner (default: `false`)
-- `-s, --skipProgressBar`: do not display the progress bar (default: `false`)
-- `-s, --sqliteoutput`: save results to a SQLite database (default: `html-report.sqlite`)
+- `-s, --dboutput`: save results to a database file (default: `html-report.duckdb` or `html-report.sqlite` with `--sqlite`)
+- `--skipProgressBar`: do not display the progress bar (default: `false`)
+- `--sqlite`: use SQLite backend instead of DuckDB (default: `false`)
 
 #### `html-report` command example
 
@@ -387,7 +411,7 @@ takajo.exe html-report -t ../hayabusa/hayabusa-results.jsonl -o htmlreport -r ..
 ### `html-server` command
 
 Create a dynamic web server to view HTML summary reports.
-This command first creates an indexed SQLite database file in order to perform fast lookups on the data needed to create the summary reports.
+This command first creates an indexed DuckDB database file (default) or SQLite database file in order to perform fast lookups on the data needed to create the summary reports.
 It is similar to the `html-report` command but is more scalable and allows for filtering on dates and rules.
 
 * Input: JSONL
@@ -400,12 +424,13 @@ Required options:
 
 Options:
 
-- `-C, --clobber`: overwrite the SQLite file when saving (default: `false`)
-- `-p, --port`: web server port number
+- `-C, --clobber`: overwrite the database file when saving (default: `false`)
+- `-p, --port`: web server port number (default: `8823`)
 - `-q, --quiet`: do not display the launch banner (default: `false`)
 - `-r, --rulepath`: path to the Hayabusa rules directory (this is optional but needed to create correct links to the rule files)
-- `-s, --skipProgressBar`: do not display the progress bar (default: `false`)
-- `-s, --sqliteoutput`: save results to a SQLite database (default: `html-report.sqlite`)
+- `-s, --dboutput`: save results to a database file (default: `html-report.duckdb` or `html-report.sqlite` with `--sqlite`)
+- `--skipProgressBar`: do not display the progress bar (default: `false`)
+- `--sqlite`: use SQLite backend instead of DuckDB (default: `false`)
 
 #### `html-report` command example
 

--- a/src/takajo.nim
+++ b/src/takajo.nim
@@ -27,6 +27,7 @@ import takajopkg/takajoCore
 import takajopkg/takajoTerminal
 import takajopkg/ttpResult
 import takajopkg/vtResult
+import takajopkg/dbAdapter
 include takajopkg/convertFlattenJson
 include takajopkg/extractCredentials
 include takajopkg/extractScriptblocks
@@ -71,8 +72,8 @@ when isMainModule:
     const example_convert_flatten_json = "  convert-flatten-json -t ../hayabusa/timeline.jsonl -o ../hayabusa/timeline-flattened.jsonl\p"
     const example_extract_credentials = "  extract-credentials -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o credentials.csv\p"
     const example_extract_scriptblocks = "  extract-scriptblocks -t ../hayabusa/timeline.jsonl [--level low]  [--skipProgressBar] -o scriptblock-logs\p"
-    const example_html_report = "  html-report -t ../hayabusa/timeline.jsonl -o ./output -r ../hayabusa/rules [--sqlite-output html-report.sqlite] [--clobber] [--skipProgressBar] \p"
-    const example_html_server = "  html-server -t ../hayabusa/timeline.jsonl [-r ../hayabusa/rules] [-p 8823] [--sqlite-output html-report.sqlite] [--clobber] [--skipProgressBar] \p"
+    const example_html_report = "  html-report -t ../hayabusa/timeline.jsonl -o ./output -r ../hayabusa/rules [--sqlite] [--dboutput html-report.duckdb] [--clobber] [--skipProgressBar] \p"
+    const example_html_server = "  html-server -t ../hayabusa/timeline.jsonl [-r ../hayabusa/rules] [-p 8823] [--sqlite] [--dboutput html-report.duckdb] [--clobber] [--skipProgressBar] \p"
     const example_list_domains = "  list-domains -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o domains.txt\p"
     const example_list_hashes = "  list-hashes -t ../hayabusa/case-1.jsonl [--skipProgressBar] -o case-1\p"
     const example_list_ip_addresses = "  list-ip-addresses -t ../hayabusa/timeline.jsonl [--skipProgressBar] -o ipAddresses.txt\p"
@@ -172,13 +173,14 @@ when isMainModule:
                 "quiet": "do not display the launch banner (default: false)",
                 "timeline": "Hayabusa JSONL timeline file or directory (profile: any verbose profile)",
                 "rulepath": "hayabusa rules directory path",
-                "sqliteoutput": "save results to a SQLite database (default: html-report.sqlite)",
+                "dboutput": "save results to a database file (default: html-report.duckdb or html-report.sqlite with --sqlite)",
+                "sqlite": "use SQLite backend instead of DuckDB (default: false)",
                 "skipProgressBar": "do not display the progress bar (default: false)",
-                "clobber": "overwrite the SQLite file when saving (default: false)",
+                "clobber": "overwrite the database file when saving (default: false)",
             },
             short = {
                 "clobber": 'C',
-                "sqlite-output": 's',
+                "dboutput": 's',
                 "output": 'o'
             }
         ],
@@ -189,15 +191,16 @@ when isMainModule:
                 "quiet": "do not display the launch banner (default: false)",
                 "timeline": "Hayabusa JSONL timeline file or directory (profile: any verbose profile)",
                 "rulepath": "hayabusa rules directory path",
-                "sqliteoutput": "save results to a SQLite database (default: html-report.sqlite)",
+                "dboutput": "save results to a database file (default: html-report.duckdb or html-report.sqlite with --sqlite)",
+                "sqlite": "use SQLite backend instead of DuckDB (default: false)",
                 "skipProgressBar": "do not display the progress bar (default: false)",
-                "clobber": "overwrite the SQLite file when saving (default: false)",
+                "clobber": "overwrite the database file when saving (default: false)",
                 "port": "web server port number"
             },
             short = {
                 "port": 'p',
                 "clobber": 'C',
-                "sqlite-output": 's',
+                "dboutput": 's',
             }
         ],
         [

--- a/src/takajopkg/dbAdapter.nim
+++ b/src/takajopkg/dbAdapter.nim
@@ -9,7 +9,8 @@ when defined(macosx):
   {.passC: "-I/opt/homebrew/include -I/usr/local/include".}
   {.passL: "-L/opt/homebrew/lib -L/usr/local/lib -lduckdb".}
 elif defined(windows):
-  {.passL: "-lduckdb".}
+  {.passC: "-Iduckdb_lib".}
+  {.passL: "-Lduckdb_lib -lduckdb".}
 else:
   {.passL: "-lduckdb".}
 

--- a/src/takajopkg/dbAdapter.nim
+++ b/src/takajopkg/dbAdapter.nim
@@ -5,8 +5,13 @@ import strutils
 # DuckDB C API bindings (minimal subset needed for this project)
 # =============================================================================
 
-{.passC: "-I/opt/homebrew/include".}
-{.passL: "-L/opt/homebrew/lib -lduckdb".}
+when defined(macosx):
+  {.passC: "-I/opt/homebrew/include -I/usr/local/include".}
+  {.passL: "-L/opt/homebrew/lib -L/usr/local/lib -lduckdb".}
+elif defined(windows):
+  {.passL: "-lduckdb".}
+else:
+  {.passL: "-lduckdb".}
 
 type
   DuckDBDatabase {.importc: "struct _duckdb_database", header: "<duckdb.h>".} = object

--- a/src/takajopkg/dbAdapter.nim
+++ b/src/takajopkg/dbAdapter.nim
@@ -1,0 +1,325 @@
+import db_connector/db_sqlite
+import strutils
+
+# =============================================================================
+# DuckDB C API bindings (minimal subset needed for this project)
+# =============================================================================
+
+{.passC: "-I/opt/homebrew/include".}
+{.passL: "-L/opt/homebrew/lib -lduckdb".}
+
+type
+  DuckDBDatabase {.importc: "struct _duckdb_database", header: "<duckdb.h>".} = object
+    internal_ptr: pointer
+  DuckDBDatabasePtr = ptr DuckDBDatabase
+
+  DuckDBConnection {.importc: "struct _duckdb_connection", header: "<duckdb.h>".} = object
+    internal_ptr: pointer
+  DuckDBConnectionPtr = ptr DuckDBConnection
+
+  DuckDBPreparedStatement {.importc: "struct _duckdb_prepared_statement", header: "<duckdb.h>".} = object
+    internal_ptr: pointer
+  DuckDBPreparedStatementPtr = ptr DuckDBPreparedStatement
+
+  DuckDBResult {.importc: "duckdb_result", header: "<duckdb.h>".} = object
+    deprecated_column_count: uint64
+    deprecated_row_count: uint64
+    deprecated_rows_changed: uint64
+    deprecated_columns: pointer
+    deprecated_error_message: cstring
+    internal_data: pointer
+
+  DuckDBState {.importc: "duckdb_state", header: "<duckdb.h>".} = enum
+    DuckDBSuccess = 0
+    DuckDBError = 1
+
+proc duckdb_open(path: cstring, out_database: ptr DuckDBDatabasePtr): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_close(database: ptr DuckDBDatabasePtr) {.importc, header: "<duckdb.h>".}
+proc duckdb_connect(database: DuckDBDatabasePtr, out_connection: ptr DuckDBConnectionPtr): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_disconnect(connection: ptr DuckDBConnectionPtr) {.importc, header: "<duckdb.h>".}
+proc duckdb_query(connection: DuckDBConnectionPtr, query: cstring, out_result: ptr DuckDBResult): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_destroy_result(result: ptr DuckDBResult) {.importc, header: "<duckdb.h>".}
+proc duckdb_column_count(result: ptr DuckDBResult): uint64 {.importc, header: "<duckdb.h>".}
+proc duckdb_row_count(result: ptr DuckDBResult): uint64 {.importc, header: "<duckdb.h>".}
+proc duckdb_value_varchar(result: ptr DuckDBResult, col: uint64, row: uint64): cstring {.importc, header: "<duckdb.h>".}
+proc duckdb_value_is_null(result: ptr DuckDBResult, col: uint64, row: uint64): bool {.importc, header: "<duckdb.h>".}
+proc duckdb_free(p: pointer) {.importc, header: "<duckdb.h>".}
+proc duckdb_result_error(result: ptr DuckDBResult): cstring {.importc, header: "<duckdb.h>".}
+
+proc duckdb_prepare(connection: DuckDBConnectionPtr, query: cstring, out_prepared_statement: ptr DuckDBPreparedStatementPtr): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_destroy_prepare(prepared_statement: ptr DuckDBPreparedStatementPtr) {.importc, header: "<duckdb.h>".}
+proc duckdb_bind_varchar(prepared_statement: DuckDBPreparedStatementPtr, param_idx: uint64, val: cstring): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_execute_prepared(prepared_statement: DuckDBPreparedStatementPtr, out_result: ptr DuckDBResult): DuckDBState {.importc, header: "<duckdb.h>".}
+proc duckdb_prepare_error(prepared_statement: DuckDBPreparedStatementPtr): cstring {.importc, header: "<duckdb.h>".}
+
+# =============================================================================
+# DbAdapter abstraction layer
+# =============================================================================
+
+type
+  DbBackend* = enum
+    backendDuckDB
+    backendSQLite
+
+  DbAdapter* = object
+    case backend*: DbBackend
+    of backendSQLite:
+      sqliteConn*: db_sqlite.DbConn
+    of backendDuckDB:
+      duckDbPtr: DuckDBDatabasePtr
+      duckConn: DuckDBConnectionPtr
+
+proc openDb*(path: string, backend: DbBackend): DbAdapter =
+  case backend
+  of backendSQLite:
+    let conn = db_sqlite.open(path, "", "", "")
+    result = DbAdapter(backend: backendSQLite, sqliteConn: conn)
+  of backendDuckDB:
+    var dbPtr: DuckDBDatabasePtr
+    var connPtr: DuckDBConnectionPtr
+    let state = duckdb_open(path.cstring, addr dbPtr)
+    if state != DuckDBSuccess:
+      raise newException(IOError, "Failed to open DuckDB database: " & path)
+    let connState = duckdb_connect(dbPtr, addr connPtr)
+    if connState != DuckDBSuccess:
+      duckdb_close(addr dbPtr)
+      raise newException(IOError, "Failed to connect to DuckDB database: " & path)
+    result = DbAdapter(backend: backendDuckDB, duckDbPtr: dbPtr, duckConn: connPtr)
+
+proc closeDb*(db: var DbAdapter) =
+  case db.backend
+  of backendSQLite:
+    db.sqliteConn.close()
+  of backendDuckDB:
+    duckdb_disconnect(addr db.duckConn)
+    duckdb_close(addr db.duckDbPtr)
+
+proc translateQuery*(query: string, backend: DbBackend): string =
+  ## Translate SQLite-specific SQL to DuckDB-compatible SQL
+  if backend == backendSQLite:
+    return query
+
+  result = query
+  # date(datetime(timestamp, 'localtime')) -> SUBSTRING(timestamp, 1, 10)
+  result = result.replace("date(datetime(timestamp, 'localtime'))", "SUBSTRING(timestamp, 1, 10)")
+  result = result.replace("date(datetime(timestamp))", "SUBSTRING(timestamp, 1, 10)")
+  # datetime(timestamp, 'localtime') -> timestamp
+  result = result.replace("datetime(timestamp, 'localtime')", "timestamp")
+  # datetime(timestamp) -> timestamp
+  result = result.replace("datetime(timestamp)", "timestamp")
+  # DATE(timestamp) -> SUBSTRING(timestamp, 1, 10)
+  result = result.replace("DATE(timestamp)", "SUBSTRING(timestamp, 1, 10)")
+
+proc exec*(db: DbAdapter, query: string) =
+  case db.backend
+  of backendSQLite:
+    db.sqliteConn.exec(db_sqlite.sql(translateQuery(query, backendSQLite)))
+  of backendDuckDB:
+    let translated = translateQuery(query, backendDuckDB)
+    var res: DuckDBResult
+    let state = duckdb_query(db.duckConn, translated.cstring, addr res)
+    if state != DuckDBSuccess:
+      let err = duckdb_result_error(addr res)
+      let errMsg = if err != nil: $err else: "unknown error"
+      duckdb_destroy_result(addr res)
+      raise newException(DbError, "DuckDB exec error: " & errMsg)
+    duckdb_destroy_result(addr res)
+
+proc getAllRows*(db: DbAdapter, query: string, args: varargs[string, `$`]): seq[seq[string]] =
+  case db.backend
+  of backendSQLite:
+    let translated = translateQuery(query, backendSQLite)
+    return db.sqliteConn.getAllRows(db_sqlite.sql(translated), args)
+  of backendDuckDB:
+    let translated = translateQuery(query, backendDuckDB)
+    # Use prepared statement if we have args
+    if args.len > 0:
+      var stmtPtr: DuckDBPreparedStatementPtr
+      let prepState = duckdb_prepare(db.duckConn, translated.cstring, addr stmtPtr)
+      if prepState != DuckDBSuccess:
+        let err = duckdb_prepare_error(stmtPtr)
+        let errMsg = if err != nil: $err else: "unknown error"
+        duckdb_destroy_prepare(addr stmtPtr)
+        raise newException(DbError, "DuckDB prepare error: " & errMsg)
+
+      for i, arg in args:
+        let bindState = duckdb_bind_varchar(stmtPtr, uint64(i + 1), arg.cstring)
+        if bindState != DuckDBSuccess:
+          duckdb_destroy_prepare(addr stmtPtr)
+          raise newException(DbError, "DuckDB bind error at param " & $(i + 1))
+
+      var res: DuckDBResult
+      let execState = duckdb_execute_prepared(stmtPtr, addr res)
+      if execState != DuckDBSuccess:
+        let err = duckdb_result_error(addr res)
+        let errMsg = if err != nil: $err else: "unknown error"
+        duckdb_destroy_result(addr res)
+        duckdb_destroy_prepare(addr stmtPtr)
+        raise newException(DbError, "DuckDB execute error: " & errMsg)
+
+      let colCount = duckdb_column_count(addr res)
+      let rowCount = duckdb_row_count(addr res)
+      result = @[]
+      for r in 0'u64 ..< rowCount:
+        var row: seq[string] = @[]
+        for c in 0'u64 ..< colCount:
+          if duckdb_value_is_null(addr res, c, r):
+            row.add("")
+          else:
+            let val = duckdb_value_varchar(addr res, c, r)
+            if val != nil:
+              row.add($val)
+              duckdb_free(cast[pointer](val))
+            else:
+              row.add("")
+        result.add(row)
+      duckdb_destroy_result(addr res)
+      duckdb_destroy_prepare(addr stmtPtr)
+    else:
+      var res: DuckDBResult
+      let state = duckdb_query(db.duckConn, translated.cstring, addr res)
+      if state != DuckDBSuccess:
+        let err = duckdb_result_error(addr res)
+        let errMsg = if err != nil: $err else: "unknown error"
+        duckdb_destroy_result(addr res)
+        raise newException(DbError, "DuckDB query error: " & errMsg)
+
+      let colCount = duckdb_column_count(addr res)
+      let rowCount = duckdb_row_count(addr res)
+      result = @[]
+      for r in 0'u64 ..< rowCount:
+        var row: seq[string] = @[]
+        for c in 0'u64 ..< colCount:
+          if duckdb_value_is_null(addr res, c, r):
+            row.add("")
+          else:
+            let val = duckdb_value_varchar(addr res, c, r)
+            if val != nil:
+              row.add($val)
+              duckdb_free(cast[pointer](val))
+            else:
+              row.add("")
+        result.add(row)
+      duckdb_destroy_result(addr res)
+
+proc getRow*(db: DbAdapter, query: string, args: varargs[string, `$`]): seq[string] =
+  let rows = db.getAllRows(query, args)
+  if rows.len > 0:
+    return rows[0]
+  else:
+    # Return empty strings matching column count (similar to db_sqlite behavior)
+    return @[]
+
+proc insertRow*(db: DbAdapter, query: string, args: varargs[string, `$`]): bool =
+  case db.backend
+  of backendSQLite:
+    let translated = translateQuery(query, backendSQLite)
+    var stmt = db.sqliteConn.prepare(translated)
+    for i, arg in args:
+      bindParam(stmt, i + 1, arg)
+    result = db.sqliteConn.tryExec(stmt)
+    finalize(stmt)
+  of backendDuckDB:
+    let translated = translateQuery(query, backendDuckDB)
+    var stmtPtr: DuckDBPreparedStatementPtr
+    let prepState = duckdb_prepare(db.duckConn, translated.cstring, addr stmtPtr)
+    if prepState != DuckDBSuccess:
+      let err = duckdb_prepare_error(stmtPtr)
+      let errMsg = if err != nil: $err else: "unknown error"
+      duckdb_destroy_prepare(addr stmtPtr)
+      raise newException(DbError, "DuckDB prepare error: " & errMsg)
+
+    for i, arg in args:
+      let bindState = duckdb_bind_varchar(stmtPtr, uint64(i + 1), arg.cstring)
+      if bindState != DuckDBSuccess:
+        duckdb_destroy_prepare(addr stmtPtr)
+        return false
+
+    var res: DuckDBResult
+    let execState = duckdb_execute_prepared(stmtPtr, addr res)
+    if execState != DuckDBSuccess:
+      duckdb_destroy_result(addr res)
+      duckdb_destroy_prepare(addr stmtPtr)
+      return false
+
+    duckdb_destroy_result(addr res)
+    duckdb_destroy_prepare(addr stmtPtr)
+    return true
+
+proc beginTransaction*(db: DbAdapter) =
+  db.exec("BEGIN TRANSACTION")
+
+proc commitTransaction*(db: DbAdapter) =
+  db.exec("COMMIT")
+
+proc quoteStr*(s: string): string =
+  ## Quote a string for use in SQL (replacement for dbQuote)
+  result = "'" & s.replace("'", "''") & "'"
+
+proc createTimelinesTable*(db: DbAdapter) =
+  case db.backend
+  of backendSQLite:
+    db.exec("""CREATE TABLE timelines (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp TEXT,
+      rule_title TEXT,
+      level TEXT,
+      level_order INTEGER,
+      computer TEXT,
+      channel TEXT,
+      event_id INTEGER,
+      record_id TEXT,
+      rule_file TEXT,
+      evtx_file TEXT,
+      rule_author TEXT,
+      rule_modified_date TEXT,
+      rule_creation_date TEXT,
+      status TEXT
+    )""")
+  of backendDuckDB:
+    db.exec("""CREATE SEQUENCE IF NOT EXISTS timelines_seq START 1""")
+    db.exec("""CREATE TABLE timelines (
+      id INTEGER DEFAULT nextval('timelines_seq'),
+      timestamp VARCHAR,
+      rule_title VARCHAR,
+      level VARCHAR,
+      level_order INTEGER,
+      computer VARCHAR,
+      channel VARCHAR,
+      event_id INTEGER,
+      record_id VARCHAR,
+      rule_file VARCHAR,
+      evtx_file VARCHAR,
+      rule_author VARCHAR,
+      rule_modified_date VARCHAR,
+      rule_creation_date VARCHAR,
+      status VARCHAR
+    )""")
+
+proc createRuleFilesTable*(db: DbAdapter) =
+  case db.backend
+  of backendSQLite:
+    db.exec("""CREATE TABLE rule_files (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      alert_title TEXT,
+      rule_path TEXT
+    )""")
+  of backendDuckDB:
+    db.exec("""CREATE SEQUENCE IF NOT EXISTS rule_files_seq START 1""")
+    db.exec("""CREATE TABLE rule_files (
+      id INTEGER DEFAULT nextval('rule_files_seq'),
+      alert_title VARCHAR,
+      rule_path VARCHAR
+    )""")
+
+proc detectBackend*(path: string): DbBackend =
+  ## Detect the database backend based on file extension
+  if path.endsWith(".sqlite"):
+    return backendSQLite
+  else:
+    return backendDuckDB
+
+proc defaultDbExtension*(backend: DbBackend): string =
+  case backend
+  of backendSQLite: return ".sqlite"
+  of backendDuckDB: return ".duckdb"

--- a/src/takajopkg/htmlReport.nim
+++ b/src/takajopkg/htmlReport.nim
@@ -1,4 +1,3 @@
-import db_connector/db_sqlite
 import streams
 
 const HtmlReportMsg = "This command will create HTML summary reports for rules and computers with detections"
@@ -21,45 +20,30 @@ proc copyDirectory(src: string, dest: string) =
 
 
 # output: HTML reports directory name
-# sqliteoutput: save results to a SQLite database
+# dboutput: save results to a database file
 # timeline: Hayabusa JSONL timeline file or directory
-proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath: string = "", clobber: bool = false, sqliteoutput: string = "html-report.sqlite", skipProgressBar: bool = false, ) =
+# sqlite: use SQLite backend (default: false, uses DuckDB)
+proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath: string = "", clobber: bool = false, dboutput: string = "", sqlite: bool = false, skipProgressBar: bool = false) =
 
     if not quiet:
         styledEcho(fgGreen, outputLogo())
 
-    if fileExists(sqliteoutput) and clobber == false:
-        echo sqliteoutput & " already exists. Please add the -C, --clobber option to overwrite the file."
+    let backend = if sqlite: backendSQLite else: backendDuckDB
+    let actualDbOutput = if dboutput != "": dboutput
+                         elif sqlite: "html-report.sqlite"
+                         else: "html-report.duckdb"
+
+    if fileExists(actualDbOutput) and clobber == false:
+        echo actualDbOutput & " already exists. Please add the -C, --clobber option to overwrite the file."
         return
 
-    # create sqlite file or open exist database file.
-    let db = open(sqliteoutput, "", "", "")
+    # create database file
+    var db = openDb(actualDbOutput, backend)
     try:
-        try:
-            let dropTableSQL = sql"""DROP TABLE timelines"""
-            db.exec(dropTableSQL)
-        except:
-            discard
+        db.exec("DROP TABLE IF EXISTS timelines")
 
         # create timelines table
-        let createTableSQL = sql"""CREATE TABLE timelines (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT,
-            rule_title TEXT,
-            level TEXT,
-            level_order INTEGER,
-            computer TEXT,
-            channel TEXT,
-            event_id INTEGER,
-            record_id TEXT,
-            rule_file TEXT,
-            evtx_file TEXT,
-            rule_author TEXT,
-            rule_modified_date TEXT,
-            rule_creation_date TEXT,
-            status TEXT
-        )"""
-        db.exec(createTableSQL)
+        db.createTimelinesTable()
 
         # read from timeline file
         # open timeline file
@@ -67,21 +51,21 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
         if fileStream == nil:
             echo "Failed to open file: ", timeline
-        
+
         var bar: SuruBar
         if not skipProgressBar:
             bar = initSuruBar()
             bar[0].total = countJsonlAndStartMsg("html-report", HtmlReportMsg, timeline)
             bar.setup()
 
-        db.exec(sql"BEGIN")
+        db.beginTransaction()
         var recordCount = 0
         while not fileStream.atEnd:
             let line = fileStream.readLine()
             if line.len > 0:
                 try:
                     #
-                    # write to sqlite
+                    # write to database
                     #
 
                     let jsonObj = parseJson(line)
@@ -129,13 +113,13 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
                     if "RuleAuthor" in jsonObj:
                         rule_author = jsonObj["RuleAuthor"].getStr()
-                    
+
                     if "RuleModifiedDate" in jsonObj:
                         rule_modified_date = jsonObj["RuleModifiedDate"].getStr()
 
                     if "Status" in jsonObj:
                         status = jsonObj["Status"].getStr()
-                    
+
                     if "RuleCreationDate" in jsonObj:
                         rule_creation_date = jsonObj["RuleCreationDate"].getStr()
 
@@ -155,39 +139,36 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                         rule_creation_date,
                         status
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
-                    
-                    var stmt = db.prepare(insertSQL)
-                    stmt.bindParams(timestamp, 
-                        rule_title, 
-                        level, 
-                        level_order,
-                        computer, 
-                        channel, 
-                        event_id, 
-                        record_id, 
-                        rule_file, 
-                        evtx_file, 
-                        rule_author, 
-                        rule_modified_date, 
-                        rule_creation_date, 
+
+                    let bres = db.insertRow(insertSQL, timestamp,
+                        rule_title,
+                        level,
+                        $level_order,
+                        computer,
+                        channel,
+                        $event_id,
+                        record_id,
+                        rule_file,
+                        evtx_file,
+                        rule_author,
+                        rule_modified_date,
+                        rule_creation_date,
                         status)
-                    let bres = db.tryExec(stmt)
-                                        
+
                     doAssert(bres)
-                    finalize(stmt)
                     recordCount += 1
                     if not skipProgressBar:
                         inc bar
                         bar.update(1000000000)
 
                     if recordCount %% 10000 == 0:
-                        db.exec(sql"COMMIT")
-                        db.exec(sql"BEGIN")
-                    
+                        db.commitTransaction()
+                        db.beginTransaction()
+
                 except CatchableError:
                     echo "Invalid JSON line: ", line
 
-        db.exec(sql"COMMIT")
+        db.commitTransaction()
         fileStream.close()
         if not skipProgressBar:
             bar.finish()
@@ -198,30 +179,30 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
         echo "Error: Database file not created!, ", e.msg
         discard
         return
-    
+
     echo "Creating HTML report. Please wait.\p"
 
     # start analysis timeline
-    # obtain datas from SQLite
-    var query = sql"""select rule_title, rule_file, level, level_order, computer, min(datetime(timestamp)) as start_date, max(datetime(timestamp)) as end_date, count(*) as count
+    # obtain datas from database
+    var queryStr = """select rule_title, rule_file, level, level_order, computer, min(datetime(timestamp)) as start_date, max(datetime(timestamp)) as end_date, count(*) as count
                         from timelines
-                        group by rule_title, level, computer
+                        group by rule_title, rule_file, level, level_order, computer
                         order by level_order
                         """
-    var alerts = db.getAllRows(query)
-    
+    var alerts = db.getAllRows(queryStr)
+
 
     # obtain computer summary
-    query = sql"""select computer, COUNT(*) AS count
+    queryStr = """select computer, COUNT(*) AS count
                         from timelines
                         group by computer
                         having COUNT(*) > 1
                         order by count desc
                         """
-    var computers = db.getAllRows(query)
+    var computers = db.getAllRows(queryStr)
 
     # obtain computer severities
-    query = sql"""SELECT
+    queryStr = """SELECT
                     computer,
                     SUM(CASE WHEN level = 'crit' THEN 1 ELSE 0 END) AS critical_count,
                     SUM(CASE WHEN level = 'high' THEN 1 ELSE 0 END) AS high_count,
@@ -232,13 +213,13 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                     GROUP BY computer
                     ORDER BY critical_count DESC, high_count DESC, medium_count DESC, low_count DESC, informational_count DESC
                     """
-    let computer_counts = db.getAllRows(query)
-    
+    let computer_counts = db.getAllRows(queryStr)
+
     # data formatting
     type
         Computer = tuple[name: string, count: int, start_date: string, end_date: string]
         Alert = tuple[title: string, rule_file: string, level: string, count: int, computers: seq[Computer]]
-    
+
     var levels = initTable[int, seq[Alert]]()
 
     proc findAlert(alerts: seq[Alert], rule_title: string): int =
@@ -276,13 +257,13 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
     #
     # obtain rule file path
-    #  
+    #
     proc findRuleFileWithName(dir: string, fileName: string) :string =
-        
+
         var foundPath = ""
         for entry in walkDir(dir):
             let path = os.lastPathPart(entry.path)
-            
+
             if entry.kind == pcFile and path == fileName:
                 foundPath = absolutePath(entry.path)
                 break
@@ -290,7 +271,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                 foundPath = findRuleFileWithName(entry.path, fileName)
                 if foundPath != "":
                     break
-        
+
         return foundPath
 
     const severity_order = @["info", "low", "med", "high", "critical"]
@@ -305,9 +286,9 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
         var ret = ""
 
         for level_order, alerts in pairs(levels):
-            
+
             # do not display info for sidebar
-            if level_order == 0: 
+            if level_order == 0:
                 continue
 
             var totalAlerts = 0
@@ -323,7 +304,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                         rulepath_list[alert.title] = rule_filepath
 
                 ret &= "<li class=\"font-semibold\"><a style=\"font-size:10pt !important;\" href=\"" & rule_filepath & "\">■" & alert.title & " (" & alert.count.intToStr & ")</a><ul>"
-            
+
                 for computer in alert.computers:
                     ret &= "<li style=\"border-bottom:3px;\"><a data-class=\"" & severity_order[level_order] & "\" style=\"font-size:10pt !important;\" href=\"./" & computer.name & ".html\" class=\"sidemenu link inline-flex items-center gap-2 rounded-lg px-2 py-1 text-sm font-semibold text-slate-600 transition hover:bg-indigo-100 hover:text-indigo-900\">" & computer.name & " (" & computer.count.intToStr & ") (" & computer.start_date & " ~ " & computer.end_date & ")</a><li>"
 
@@ -333,11 +314,11 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
     let sidemenu = printSideMenu(levels, rulepath, rulepath_list)
 
-    proc printSideMenuComputer(computers: seq[seq[string]]): string = 
+    proc printSideMenuComputer(computers: seq[seq[string]]): string =
         var ret = ""
         for computer in computers:
             ret &= "<li><a data-class=\"computer\" style=\"font-size:10pt !important;\" href=\"./" & computer[0] & ".html\" class=\"sidemenu inline-flex items-center gap-2 rounded-lg px-2 py-1 text-sm font-semibold text-slate-600 transition hover:bg-indigo-100 hover:text-indigo-900\">" & computer[0] & "(" & computer[1] & ")</a></li>"
-        
+
         return ret
 
     let sidemenucomputers = printSideMenuComputer(computers)
@@ -356,7 +337,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
     # data aggregation
     #
     proc collectSummaryData(levels: Table[int, seq[Alert]]): Table[int, SummaryInfo] =
-    
+
         var totalDetections = 0
         var uniqueDetections = 0
         var summaryData = initTable[int, SummaryInfo]()
@@ -368,7 +349,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
             for alert in alerts:
                 totalCount += alert.count
-            
+
                 for computer in alert.computers:
                     let date = computer.start_date.split(" ")[0]
                     if dateCounts.hasKey(date):
@@ -406,13 +387,13 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
     #
     # create a summary
     #
-    proc printSummaryData(data: Table[int, SummaryInfo], date_with_most_total_detection_list: seq[Row]): (string, string) =
+    proc printSummaryData(data: Table[int, SummaryInfo], date_with_most_total_detection_list: seq[seq[string]]): (string, string) =
 
         var detections = ""
-        
+
         for level_order in countdown(4, 0):
             if not data.hasKey(level_order):
-                continue 
+                continue
             let info = data[level_order]
             let tmp_total_percent = info.totalPercent.formatFloat(ffDecimal, 2)
             let tmp_unique_percent = info.uniquePercent.formatFloat(ffDecimal, 2)
@@ -423,7 +404,6 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
             detections &= "</tr>"
 
         var date_with_most_total_detections = ""
-        # for level_order in countdown(4, 0):
         for value in date_with_most_total_detection_list:
             let key = parseInt(value[0])
             date_with_most_total_detections &= "<tr class=\"border-b border-gray-100\">"
@@ -434,7 +414,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
         return (detections, date_with_most_total_detections)
 
-    query = sql"""WITH max_detections AS (
+    queryStr = """WITH max_detections AS (
                     SELECT
                         level_order,
                         DATE(timestamp) AS detection_date,
@@ -465,11 +445,11 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                     ELSE 6
                 END;
                 """
-    var dates_with_most_total_detection_list = db.getAllRows(query) 
+    var dates_with_most_total_detection_list = db.getAllRows(queryStr)
     let (detections, date_with_most_total_detections) = printSummaryData(summaryData, dates_with_most_total_detection_list)
-    
+
     # Rule Summary
-    proc printDetectionRuleList(levels: seq[(int, seq[Alert])], rulepath: string, rulepath_list: var Table[string, string]): string = 
+    proc printDetectionRuleList(levels: seq[(int, seq[Alert])], rulepath: string, rulepath_list: var Table[string, string]): string =
         var ret = ""
         const severity_order = @["Information", "Low", "Medium", "High", "Critical"]
 
@@ -513,7 +493,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
     # read template file
     var f: File = open("./templates/index.template", FileMode.fmRead)
-    
+
     var html = ""
     while f.endOfFile == false :
         html &= f.readLine()
@@ -526,16 +506,16 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
     html = html.replace("[%DETECTIONS%]", detections)
     html = html.replace("[%DATE_WITH_MOST_TOTAL_DETECTIONS%]", date_with_most_total_detections)
     html = html.replace("[%DETECTION_RULE_LIST%]", detection_rule_list)
-    
+
     # output HTML
-    let output_path = "./" & output 
+    let output_path = "./" & output
     if not dirExists(output_path):
         try:
             createDir(output_path)
         except OSError as e:
             echo "Failed to create directory: ", e.msg
             return
- 
+
     var write: File = open(output_path & "/index.html", FileMode.fmWrite)
     write.writeLine(html)
     write.close()
@@ -545,11 +525,10 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
         ComputerSummary = object
             totalDetections: Table[int, int]
             detectionsByDate: Table[string, seq[int]]
-            #detectedRules: seq[(string, string, int)]
             detectedRules: seq[(string, int, int, string, string)]
 
     var computerSummaries = initTable[string, ComputerSummary]()
-    
+
     for level_order, alerts in pairs(levels):
         for alert in alerts:
             for computer in alert.computers:
@@ -573,9 +552,9 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                 let date = computer.start_date.split(" ")[0]  # only the date portion is acquired.
                 if not compSummary.detectionsByDate.hasKey(date):
                     compSummary.detectionsByDate[date] = @[0, 0, 0, 0, 0]
-                
+
                 compSummary.detectionsByDate[date][level_order] += computer.count
-                
+
                 # List of detected rules
                 if not ((alert.title, level_order, alert.count, computer.start_date, computer.end_date) in compSummary.detectedRules):
                     compSummary.detectedRules.add((alert.title, level_order, alert.count, computer.start_date, computer.end_date))
@@ -585,10 +564,10 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
 
     for compName, summary in pairs(computerSummaries):
-        
+
         # read template file
         var f: File = open("./templates/content.template", FileMode.fmRead)
-    
+
         var html = ""
         while f.endOfFile == false :
             html &= f.readLine()
@@ -598,22 +577,20 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
         html = html.replace("[%PAGE_TITLE%]", compName)
         html = html.replace("[%SIDE_MENU%]", sidemenu)
         html = html.replace("[%SIDE_MENU_COMPUTER%]", sidemenucomputers)
-    
-        # html = html.replace("[%CONTENT%]", summaryHtml)
 
         for level_order, count in pairs(summary.totalDetections):
             html = html.replace("[%" & severity_order[level_order].toUpper & "_NUM%]", count.intToStr)
 
 
-        # obtain datas from SQLite
-        query = sql"""select level, level_order, date(datetime(timestamp, 'localtime')) as date, count(*) as count
+        # obtain datas from database
+        queryStr = """select level, level_order, date(datetime(timestamp, 'localtime')) as date, count(*) as count
                         from timelines
                         where computer = ?
-                        group by date, level_order
+                        group by date, level, level_order
                         order by date, level_order
                         """
-        var computer_alerts = db.getAllRows(query, compName)
-        
+        var computer_alerts = db.getAllRows(queryStr, compName)
+
         # Display data in sorted order
         type
             SeverityTable = Table[int, string]
@@ -627,20 +604,20 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
             for index in 0..4:
                 severityTable[index] = "0"
             severityTable[parseInt(alert[1])] = alert[3]
-            date_table[alert[2]] = severityTable    
-        
+            date_table[alert[2]] = severityTable
+
         let date_list = date_table.keys.toSeq.sorted()
         for date in date_list:
             for index in 0..4:
                 datasets_html[index] &= date_table[date][index] & ","
-                 
-            date_html &= "'" & date & "'," 
+
+            date_html &= "'" & date & "',"
         date_html = date_html[0..^2]
 
         for index in 0..4:
             if datasets_html[index].endsWith(","):
                 datasets_html[index] = datasets_html[index][0..^2]
-        
+
         html = html.replace("[%DATE_STR%]", date_html)
         html = html.replace("[%CRITICAL_GRAPH%]", datasets_html[4])
         html = html.replace("[%HIGH_GRAPH%]", datasets_html[3])
@@ -656,7 +633,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
         temp_html &= "<th class=\"min-w-[180px] py-3 pe-3 text-start text-sm font-semibold uppercase tracking-wider text-slate-700\">First Date</th>"
         temp_html &= "<th class=\"min-w-[180px] py-3 pe-3 text-start text-sm font-semibold uppercase tracking-wider text-slate-700\">Last Date</th>"
         temp_html &= "</tr></thead><tbody>"
-        
+
         # sort by severity order
         proc severityCompare(a, b: (string, int, int, string, string)): int =
             let firstComparison = cmp(a[1], b[1])
@@ -664,7 +641,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
                 return firstComparison
             return cmp(a[2], b[2])
         let detectedRules = summary.detectedRules.sorted(severityCompare, Descending)
-        
+
         for rule in detectedRules:
             var rule_filepath = ""
             if rulepath_list.hasKey(rule[0]):
@@ -690,9 +667,9 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
 
 
     #
-    # close sqlite file
+    # close database file
     #
-    db.close()
+    db.closeDb()
 
     #
     # create commputer summary
@@ -743,7 +720,7 @@ proc htmlReport*(output: string, quiet: bool = false, timeline: string, rulepath
     let sourceDir = "./templates/webfonts"
     let destinationDir = "./" & output & "/webfonts"
     copyDirectory(sourceDir, destinationDir)
-    
+
     echo "HTML report completed."
     echo ""
     echo "Please open \"" & output & "/index.html\""

--- a/src/takajopkg/web/controllers/computers.nim
+++ b/src/takajopkg/web/controllers/computers.nim
@@ -1,8 +1,8 @@
 import json
 import prologue
-import db_connector/db_sqlite
 import strutils
 import times
+import ../../dbAdapter
 
 proc getDBPath(ctx: Context) : string =
     let settings = getOrDefault(ctx.gScope.settings, "prologue")
@@ -44,7 +44,7 @@ proc computer*(ctx: Context) {.async.} =
         custom_query &= " AND timestamp >= ? "
         let thirtyDaysAgo = now() - (30.days)
         params.add(format(thirtyDaysAgo, "yyyy-MM-dd") & " 00:00:00")
-        
+
 
     let rule_title = ctx.request.queryParams.getOrDefault("rule_title", "")
     if rule_title != "":
@@ -53,14 +53,13 @@ proc computer*(ctx: Context) {.async.} =
         var count = 0
         let rule_title_list_last = len(rule_title_list) - 1
         for rule_title in rule_title_list:
-            #custom_query &= "'" & rule_title & "'"
             custom_query &= "?"
             if count != rule_title_list_last:
                 custom_query &= ","
             count += 1
             params.add(rule_title)
         custom_query &= ")"
-        
+
 
     let severities = ctx.request.queryParams.getOrDefault("severities", "")
     if severities != "":
@@ -69,26 +68,24 @@ proc computer*(ctx: Context) {.async.} =
         for severity in severity_ary:
             if severity_query.len > 0:
                 severity_query &= ", "
-            severity_query &= dbQuote(severity)
+            severity_query &= quoteStr(severity)
         custom_query &= " AND level IN (" & severity_query & ")"
-
-    # echo custom_query
-    # echo params
 
     #
     # query to DB
     #
     try:
         let path = getDBPath(ctx)
-        let db = open(path , "", "", "")
+        let backend = detectBackend(path)
+        var db = openDb(path, backend)
 
         var query = """select rule_title, rule_file, level, level_order, computer, min(datetime(timestamp)) as start_date, max(datetime(timestamp)) as end_date, count(*) as count
                         from timelines
                         where """ & custom_query &  """
-                        group by rule_title, level, computer
+                        group by rule_title, rule_file, level, level_order, computer
                         order by level_order
                         """
-        var alerts = db.getAllRows(sql query, params) 
+        var alerts = db.getAllRows(query, params)
 
         query = """SELECT
                     SUM(CASE WHEN level = 'crit' THEN 1 ELSE 0 END) AS critical_count,
@@ -99,15 +96,17 @@ proc computer*(ctx: Context) {.async.} =
                     FROM timelines
                     where """ & custom_query &  """
                     """
-        let computer_counts = db.getRow(sql query, params) 
+        let computer_counts = db.getRow(query, params)
 
         query = """select level, level_order, date(datetime(timestamp)) AS date, count(*) as count
                         from timelines
                         where """ & custom_query &  """
-                        group by date, level_order
+                        group by date, level, level_order
                         order by date, level_order
                         """
-        let graph_data = db.getAllRows(sql query, params) 
+        let graph_data = db.getAllRows(query, params)
+
+        db.closeDb()
 
         let response = %* {
             "alerts": alerts,
@@ -129,9 +128,10 @@ proc sidemenu*(ctx: Context) {.async.} =
     #
     try:
         let path = getDBPath(ctx)
-        let db = open(path , "", "", "")
+        let backend = detectBackend(path)
+        var db = openDb(path, backend)
 
-        var query = sql"""SELECT 
+        var query = """SELECT
                             level as severity,
                             rule_title,
                             computer,
@@ -139,10 +139,12 @@ proc sidemenu*(ctx: Context) {.async.} =
                             MIN(datetime(timestamp)) AS first_date,
                             MAX(datetime(timestamp)) AS last_date
                         FROM timelines
-                        GROUP BY level_order, rule_title, computer
+                        GROUP BY level, level_order, rule_title, computer
                         ORDER BY level_order, rule_title, computer;
                     """
         var sidemenu = db.getAllRows(query)
+        db.closeDb()
+
         let response = %* {
             "sidemenu": sidemenu
         }
@@ -163,9 +165,10 @@ proc summary*(ctx: Context) {.async.} =
     #
     try:
         let path = getDBPath(ctx)
-        let db = open(path , "", "", "")
+        let backend = detectBackend(path)
+        var db = openDb(path, backend)
 
-        var query = sql"""SELECT
+        var query = """SELECT
                         computer,
                         SUM(CASE WHEN level = 'crit' THEN 1 ELSE 0 END) AS "Critical Alerts",
                         SUM(CASE WHEN level = 'high' THEN 1 ELSE 0 END) AS "High Alerts",
@@ -184,6 +187,8 @@ proc summary*(ctx: Context) {.async.} =
                         "Informational Alerts" DESC;
                     """
         var summary = db.getAllRows(query)
+        db.closeDb()
+
         let response = %* {
             "summary": summary
         }

--- a/src/takajopkg/web/controllers/rules.nim
+++ b/src/takajopkg/web/controllers/rules.nim
@@ -1,7 +1,7 @@
 import json
 import prologue
-import db_connector/db_sqlite
 import strutils
+import ../../dbAdapter
 
 proc getDBPath(ctx: Context) : string =
     let settings = getOrDefault(ctx.gScope.settings, "prologue")
@@ -14,10 +14,13 @@ proc list*(ctx: Context) {.async.} =
     #
     try:
         let path = getDBPath(ctx)
-        let db = open(path , "", "", "")
+        let backend = detectBackend(path)
+        var db = openDb(path, backend)
 
         let query = """SELECT alert_title, rule_path FROM rule_files"""
-        let rules = db.getAllRows(sql query) 
+        let rules = db.getAllRows(query)
+
+        db.closeDb()
 
         let response = %* {
             "rules": rules
@@ -36,7 +39,8 @@ proc getRuleContent*(ctx: Context) {.async.} =
   #
   try:
     let path = getDBPath(ctx)
-    let db = open(path, "", "", "")
+    let backend = detectBackend(path)
+    var db = openDb(path, backend)
 
     let query = """SELECT rule_path FROM rule_files WHERE alert_title = ?"""
     let alertTitle = ctx.request.queryParams["alert_title"]
@@ -45,7 +49,9 @@ proc getRuleContent*(ctx: Context) {.async.} =
       resp jsonResponse(response, Http400)
       return
 
-    let rulePathRow = db.getRow(sql query, alertTitle)
+    let rulePathRow = db.getRow(query, alertTitle)
+    db.closeDb()
+
     if rulePathRow.len == 0:
       let response = %*{"message": "No rule found for the given alert_title"}
       resp jsonResponse(response, Http404)
@@ -55,7 +61,7 @@ proc getRuleContent*(ctx: Context) {.async.} =
     let yamlContent = readFile(rulePath)
 
     let response = %*{
-      "alert_title": alert_title,
+      "alert_title": alertTitle,
       "rule_path": rulePath,
       "yaml_content": yamlContent
     }

--- a/src/takajopkg/web/controllers/summary.nim
+++ b/src/takajopkg/web/controllers/summary.nim
@@ -1,8 +1,8 @@
 import json
 import prologue
-import db_connector/db_sqlite
 import strutils
 import times
+import ../../dbAdapter
 
 proc getDBPath(ctx: Context) : string =
     let settings = getOrDefault(ctx.gScope.settings, "prologue")
@@ -53,17 +53,16 @@ proc list*(ctx: Context) {.async.} =
         for severity in severity_ary:
             if severity_query.len > 0:
                 severity_query &= ", "
-            severity_query &= dbQuote(severity)
+            severity_query &= quoteStr(severity)
         custom_query &= " AND level IN (" & severity_query & ")"
-
-    # echo custom_query
 
     #
     # query to DB
     #
     try:
         let path = getDBPath(ctx)
-        let db = open(path , "", "", "")
+        let backend = detectBackend(path)
+        var db = openDb(path, backend)
 
         var query = """SELECT level,
                         COUNT(*) AS total_detections,
@@ -82,7 +81,7 @@ proc list*(ctx: Context) {.async.} =
                             ELSE 6
                         END;
                         """
-        var summary = db.getAllRows(sql query, params) 
+        var summary = db.getAllRows(query, params)
 
         query = """WITH max_detections AS (
                     SELECT
@@ -115,15 +114,17 @@ proc list*(ctx: Context) {.async.} =
                     ELSE 6
                 END;
                 """
-        var dates_with_most_total_detections = db.getAllRows(sql query, params) 
+        var dates_with_most_total_detections = db.getAllRows(query, params)
 
-        query = """SELECT level, level_order, rule_title, computer, COUNT(*) AS alert_count, 
+        query = """SELECT level, level_order, rule_title, computer, COUNT(*) AS alert_count,
                     MIN(DATE(timestamp)) AS first_seen, MAX(DATE(timestamp)) AS last_seen
                     FROM timelines
-                    GROUP BY level, rule_title, computer
+                    GROUP BY level, level_order, rule_title, computer
                     ORDER BY level_order DESC
                 """
-        var all_alerts = db.getAllRows(sql query, params) 
+        var all_alerts = db.getAllRows(query, params)
+
+        db.closeDb()
 
         let response = %* {
             "summary": summary,

--- a/src/takajopkg/web/htmlServer.nim
+++ b/src/takajopkg/web/htmlServer.nim
@@ -3,80 +3,60 @@ import urls
 
 #
 # obtain rule file path
-#  
+#
 proc findRuleFileWithName(original_dir: string, dir: string, fileName: string) :string =
-    
+
     var l_rule_url = ""
     for entry in walkDir(dir):
-        let path = os.lastPathPart(entry.path)        
+        let path = os.lastPathPart(entry.path)
         if entry.kind == pcFile and path == fileName:
-            l_rule_url = entry.path            
+            l_rule_url = entry.path
             break
         elif entry.kind == pcDir:
             l_rule_url = findRuleFileWithName(original_dir, entry.path, fileName)
             if l_rule_url != "":
                 break
-    
+
     return l_rule_url
 
-proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clobber: bool = false, sqliteoutput: string = "html-report.sqlite", skipProgressBar: bool = false): bool =
+proc createDatabase*(quiet: bool = false, timeline: string, rulepath: string, clobber: bool = false, dboutput: string = "html-report.duckdb", sqlite: bool = false, skipProgressBar: bool = false): bool =
 
     if not quiet:
         styledEcho(fgGreen, outputLogo())
 
-    if fileExists(sqliteoutput) and clobber == false:
-        echo sqliteoutput & " already exists. It looks like you have already processed the JSONL file. Do you want to use this file (Y/n):"
-        
+    let backend = if sqlite: backendSQLite else: backendDuckDB
+    let actualDbOutput = if dboutput != "":
+                           dboutput
+                         elif sqlite:
+                           "html-report.sqlite"
+                         else:
+                           "html-report.duckdb"
+
+    if fileExists(actualDbOutput) and clobber == false:
+        echo actualDbOutput & " already exists. It looks like you have already processed the JSONL file. Do you want to use this file (Y/n):"
+
         while true:
-            let input = stdin.readLine().strip()            
+            let input = stdin.readLine().strip()
             if input == "" or input.toLowerAscii() == "y":
-                return true # use already sqlite file
+                return true # use already existing database file
             elif input.toLowerAscii() == "n":
-                break # create new sqlite file
+                break # create new database file
             else:
                 echo "Invalid input"
-        
-    # create sqlite file or open exist database file.
-    let db = open(sqliteoutput, "", "", "")
+
+    # create database file
+    var db = openDb(actualDbOutput, backend)
     try:
 
         # drop tables
-        try:
-            var dropTableSQL = sql"""DROP TABLE timelines"""
-            db.exec(dropTableSQL)
-        
-            dropTableSQL = sql"""DROP TABLE rule_files"""
-            db.exec(dropTableSQL)
-        except:
-            discard
+        db.exec("DROP TABLE IF EXISTS timelines")
+        db.exec("DROP TABLE IF EXISTS rule_files")
 
         # create timelines table
-        var createTableSQL = sql"""CREATE TABLE timelines (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp TEXT,
-            rule_title TEXT,
-            level TEXT,
-            level_order INTEGER,
-            computer TEXT,
-            channel TEXT,
-            event_id INTEGER,
-            record_id TEXT,
-            rule_file TEXT,
-            evtx_file TEXT,
-            rule_author TEXT,
-            rule_modified_date TEXT,
-            rule_creation_date TEXT,
-            status TEXT
-        )"""
-        db.exec(createTableSQL)
+        db.createTimelinesTable()
 
         # create rule_files table
-        createTableSQL = sql"""CREATE TABLE rule_files (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            alert_title TEXT,
-            rule_path TEXT
-        )"""
-        db.exec(createTableSQL)
+        db.createRuleFilesTable()
 
         # read from timeline file
         # open timeline file
@@ -85,14 +65,14 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
         if fileStream == nil:
             echo "Failed to open file: ", timeline
             return false
-        
+
         var bar: SuruBar
         if not skipProgressBar:
             bar = initSuruBar()
             bar[0].total = countJsonlAndStartMsg("html-report", HtmlReportMsg, timeline)
             bar.setup()
 
-        db.exec(sql"BEGIN")
+        db.beginTransaction()
         var recordCount = 0
         var alert_title_list: seq[(string, string)] = @[]
 
@@ -102,7 +82,7 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
             if line.len > 0:
                 try:
                     #
-                    # write to sqlite
+                    # write to database
                     #
 
                     let jsonObj = parseJson(line)
@@ -127,7 +107,7 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
                         record_id = jsonObj["RecordID"].getStr()
                     let rule_file = jsonObj["RuleFile"].getStr()
                     let evtx_file = jsonObj["EvtxFile"].getStr()
-            
+
                     if (rule_title, rule_file) notin alert_title_list:
                         alert_title_list.add((rule_title, rule_file))
 
@@ -154,13 +134,13 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
 
                     if "RuleAuthor" in jsonObj:
                         rule_author = jsonObj["RuleAuthor"].getStr()
-                    
+
                     if "RuleModifiedDate" in jsonObj:
                         rule_modified_date = jsonObj["RuleModifiedDate"].getStr()
 
                     if "Status" in jsonObj:
                         status = jsonObj["Status"].getStr()
-                    
+
                     if "RuleCreationDate" in jsonObj:
                         rule_creation_date = jsonObj["RuleCreationDate"].getStr()
 
@@ -180,35 +160,32 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
                         rule_creation_date,
                         status
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
-                    
-                    var stmt = db.prepare(insertSQL)
-                    stmt.bindParams(timestamp, 
-                        rule_title, 
-                        level, 
-                        level_order,
-                        computer, 
-                        channel, 
-                        event_id, 
-                        record_id, 
-                        rule_file, 
-                        evtx_file, 
-                        rule_author, 
-                        rule_modified_date, 
-                        rule_creation_date, 
+
+                    let bres = db.insertRow(insertSQL, timestamp,
+                        rule_title,
+                        level,
+                        $level_order,
+                        computer,
+                        channel,
+                        $event_id,
+                        record_id,
+                        rule_file,
+                        evtx_file,
+                        rule_author,
+                        rule_modified_date,
+                        rule_creation_date,
                         status)
-                    let bres = db.tryExec(stmt)
-                                        
+
                     doAssert(bres)
-                    finalize(stmt)
                     recordCount += 1
                     if not skipProgressBar:
                         inc bar
                         bar.update(1000000000)
 
                     if recordCount %% 10000 == 0:
-                        db.exec(sql"COMMIT")
-                        db.exec(sql"BEGIN")
-                    
+                        db.commitTransaction()
+                        db.beginTransaction()
+
                 except CatchableError:
                     echo "Invalid JSON line: ", line
 
@@ -217,15 +194,12 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
                 alert_title,
                 rule_path
             ) VALUES (?, ?)"""
-            
-            var local_rule_path = findRuleFileWithName(rulepath, rulepath, rule_file)                    
-            var stmt = db.prepare(insertSQL)
-            stmt.bindParams(rule_title, local_rule_path)
-            let bres = db.tryExec(stmt)
-            doAssert(bres)
-            finalize(stmt)
 
-        db.exec(sql"COMMIT")
+            var local_rule_path = findRuleFileWithName(rulepath, rulepath, rule_file)
+            let bres = db.insertRow(insertSQL, rule_title, local_rule_path)
+            doAssert(bres)
+
+        db.commitTransaction()
         fileStream.close()
         if not skipProgressBar:
             bar.finish()
@@ -236,7 +210,8 @@ proc createSQLite*(quiet: bool = false, timeline: string, rulepath: string, clob
         echo "Error: Database file not created!, ", e.msg
         discard
         return false
-    
+
+    db.closeDb()
     return true
 
 
@@ -253,7 +228,7 @@ proc initialServer(port: int) =
     f.close()
 
     html = html.replace("[%PORT%]", $port)
-    
+
     var write = open("./templates/static/js/common.js", FileMode.fmWrite)
     write.writeLine(html)
     write.close()
@@ -261,27 +236,35 @@ proc initialServer(port: int) =
 
 #
 # Server Settings
-# 
-proc htmlServer*(port: int = 8823, quiet: bool = false, timeline: string, rulepath: string = "", clobber: bool = false, sqliteoutput: string = "html-report.sqlite", skipProgressBar: bool = false) =
-    
-    let ret = createSQLite(quiet, timeline, rulepath, clobber, sqliteoutput, skipProgressBar)
+#
+proc htmlServer*(port: int = 8823, quiet: bool = false, timeline: string, rulepath: string = "", clobber: bool = false, dboutput: string = "", sqlite: bool = false, skipProgressBar: bool = false) =
+
+    let backend = if sqlite: backendSQLite else: backendDuckDB
+    let actualDbOutput = if dboutput != "":
+                           dboutput
+                         elif sqlite:
+                           "html-report.sqlite"
+                         else:
+                           "html-report.duckdb"
+
+    let ret = createDatabase(quiet, timeline, rulepath, clobber, actualDbOutput, sqlite, skipProgressBar)
     if ret == false:
         return
-    
 
-    if fileExists(sqliteoutput) == false:
-        echo "Not found sqlite file: " & sqliteoutput
+
+    if fileExists(actualDbOutput) == false:
+        echo "Not found database file: " & actualDbOutput
         return
 
     initialServer(port)
 
     let settings = newSettings(
-        appName = sqliteoutput,
+        appName = actualDbOutput,
         debug = false,
-        port = Port(port)        
+        port = Port(port)
     )
     echo "You can access the HTML summary reports at http://localhost:" & $port
 
     let app = newApp(settings = settings)
-    app.addRoute(urls.urlPatterns, "")    
+    app.addRoute(urls.urlPatterns, "")
     app.run()

--- a/src/takajopkg/web/htmlServer.nim
+++ b/src/takajopkg/web/htmlServer.nim
@@ -1,6 +1,8 @@
 import prologue
 import urls
 
+const HtmlServerMsg = "This command will create a web server that hosts a dynamic summaries for rules and computers with detections."
+
 #
 # obtain rule file path
 #
@@ -69,7 +71,7 @@ proc createDatabase*(quiet: bool = false, timeline: string, rulepath: string, cl
         var bar: SuruBar
         if not skipProgressBar:
             bar = initSuruBar()
-            bar[0].total = countJsonlAndStartMsg("html-report", HtmlReportMsg, timeline)
+            bar[0].total = countJsonlAndStartMsg("html-server", HtmlServerMsg, timeline)
             bar.setup()
 
         db.beginTransaction()


### PR DESCRIPTION
Add DuckDB as the default database backend for html-report and html-server commands, with --sqlite flag to use SQLite as a fallback. DuckDB provides 4-24x faster analytical queries and ~7x smaller file sizes.

- Add dbAdapter.nim with direct C FFI bindings to DuckDB
- Add --sqlite flag and --dboutput parameter to CLI
- Migrate all controllers and report generators to use dbAdapter
- Handle SQL dialect differences (GROUP BY strictness, date functions, DDL)