### PR TITLE
chg: update third-party action versions and add permissions to workflows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,5 +1,8 @@
 name: Integration-Test
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 
@@ -8,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup Nim
-        uses: jiro4989/setup-nim-action@v2
+        uses: jiro4989/setup-nim-action@cb1fc1270b117457dd0d9f610ec981fad3369cec # v2.3.0
         with:
           nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: clone takajo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: takajo
@@ -35,14 +38,14 @@ jobs:
           cd ../
 
       - name: clone hayabusa
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa
           submodules: recursive
           path: hayabusa
 
       - name: clone hayabusa-sample-evtx
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Yamato-Security/hayabusa-sample-evtx
           path: hayabusa-sample-evtx

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -1,5 +1,8 @@
 name: Nim
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:
@@ -26,8 +29,8 @@ jobs:
             }
     runs-on: ${{ matrix.info.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: jiro4989/setup-nim-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: jiro4989/setup-nim-action@cb1fc1270b117457dd0d9f610ec981fad3369cec # v2.3.0
         with:
           nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Takajo Release Automation
 
+permissions: {}
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +14,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.inputs.branch_or_tag }}
 
       - name: Setup Nim
-        uses: jiro4989/setup-nim-action@v2
+        uses: jiro4989/setup-nim-action@cb1fc1270b117457dd0d9f610ec981fad3369cec # v2.3.0
         with:
           nim-version: '2.x' # default is 'stable'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +116,7 @@ jobs:
           esac
 
       - name: Upload Zip Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.set_artifact_name.outputs.artifact_name }}
           path: |
@@ -120,9 +124,9 @@ jobs:
 
       - name: Setup node
         if: matrix.os == 'macos-latest'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Create PDF
         if: matrix.os == 'macos-latest'
@@ -136,7 +140,7 @@ jobs:
 
       - name: Upload Document Artifacts
         if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: documents
           path: |
@@ -147,14 +151,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-packages
           pattern: takajo-*
           merge-multiple: true
 
       - name: Upload Artifacts(all-platforms)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: takajo-${{ github.event.inputs.release_ver }}-all-platforms
           path: all-packages/*
@@ -165,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-packages
           pattern: takajo-*
@@ -178,7 +182,7 @@ jobs:
             cd ..
           done
       - name: Upload Zip Artifacts(all-packages)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: all-packages
           path: all-packages/*.zip

--- a/takajo.nimble
+++ b/takajo.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "2.15.2"
+version       = "2.16.0"
 author        = "Yamato Security @SecurityYamato"
 description   = "Takajo is an analyzer for Hayabusa results."
 license       = "AGPL-3.0"


### PR DESCRIPTION
## What Changed
I have updated third-party action references to use full-length commit SHA, following the best practices.
- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

## Test
### Integration-Test
- https://github.com/Yamato-Security/takajo/actions/runs/25241240616

I’d appreciate it if you could check it when you have time🙏

