### PR TITLE
ci: remove the PDF documentation creation from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,30 +123,6 @@ jobs:
           path: |
             release-binaries/*
 
-      - name: Setup node
-        if: matrix.os == 'macos-latest'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - name: Create PDF
-        if: matrix.os == 'macos-latest'
-        run: |
-          npm i -g md-to-pdf
-          md-to-pdf ./*.md --md-file-encoding utf-8
-          mv ./README.pdf ./README-${{ github.event.inputs.release_ver }}-English.pdf
-          mv ./README-Japanese.pdf ./README-${{ github.event.inputs.release_ver }}-Japanese.pdf
-          mv ./CHANGELOG.pdf ./CHANGELOG-${{ github.event.inputs.release_ver }}-English.pdf
-          mv ./CHANGELOG-Japanese.pdf ./CHANGELOG-${{ github.event.inputs.release_ver }}-Japanese.pdf
-
-      - name: Upload Document Artifacts
-        if: matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: documents
-          path: |
-            ./*.pdf
-
   upload-all-platforms:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes the PDF documentation generation from the release automation (`.github/workflows/release.yml`).

The `release` job had three `macos-latest`-gated steps dedicated to producing PDFs:
- **Setup node** — only needed to install `md-to-pdf`;
- **Create PDF** — `npm i -g md-to-pdf` + converting `README*.md` / `CHANGELOG*.md` to PDF and renaming them per release version;
- **Upload Document Artifacts** — uploaded `./*.pdf` as a separate `documents` artifact.

All three are removed. The `documents` artifact was **not consumed by any downstream job** — `upload-all-platforms` and `all-packages-zip` both download with `pattern: takajo-*` — so this does not change the released binaries or the all-platforms/all-packages bundles.

YAML validated; no lingering `pdf`/`md-to-pdf`/`documents`/`setup-node` references remain.